### PR TITLE
Removed Grey Terminator Ancient weapon options

### DIFF
--- a/Imperium - Grey Knights.cat
+++ b/Imperium - Grey Knights.cat
@@ -1,26 +1,85 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="50c4-3e83-fe54-97c4" name="Imperium - Grey Knights" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" revision="16" battleScribeVersion="2.03" type="catalogue">
-  <catalogueLinks>
-    <catalogueLink type="catalogue" name="Imperium - Imperial Knights" id="f3e4-7fc3-8f57-6303" importRootEntries="true" targetId="1b6d-dc06-5db9-c7d1"/>
-    <catalogueLink type="catalogue" name="Imperium - Imperial Agents" id="575c-d0f9-7fdc-2ddb" targetId="b00-cd86-4b4c-97ba" importRootEntries="true"/>
-    <catalogueLink type="catalogue" name="Library - Titans" id="9d21-5393-3605-a43e" targetId="7481-280e-b55e-7867"/>
-  </catalogueLinks>
+<catalogue id="50c4-3e83-fe54-97c4" name="Imperium - Grey Knights" revision="14" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="9" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="71ac-a100-1ec8-14e9" name="Brother-Captain" hidden="false"/>
+    <categoryEntry id="9e54-c14b-9ec9-e387" name="Brother-Captain Stern" hidden="false"/>
+    <categoryEntry id="c427-b327-40a0-a401" name="Brotherhood Champion" hidden="false"/>
+    <categoryEntry id="ebf4-5ffe-19e7-c6c7" name="Brotherhood Chaplain" hidden="false"/>
+    <categoryEntry id="bd80-12a6-cd23-96c9" name="Brotherhood Librarian" hidden="false"/>
+    <categoryEntry id="c352-657f-d2cc-adcf" name="Brotherhood Techmarine" hidden="false"/>
+    <categoryEntry id="cddf-ac1-4a0d-8e48" name="Brotherhood Terminator Squad" hidden="false"/>
+    <categoryEntry id="de95-1b68-44cf-7ca9" name="Castellan Crowe" hidden="false"/>
+    <categoryEntry id="ce31-227c-65ca-e27e" name="Grand Master" hidden="false"/>
+    <categoryEntry id="a738-1a96-db57-ba6f" name="Grand Master in Nemesis Dreadknight" hidden="false"/>
+    <categoryEntry id="472c-f807-880-b6" name="Grand Master Voldus" hidden="false"/>
+    <categoryEntry id="adfb-534b-3eb7-2781" name="Grey Knights Land Raider" hidden="false"/>
+    <categoryEntry id="4a04-1f1b-8ffb-b183" name="Grey Knights Land Raider Crusader" hidden="false"/>
+    <categoryEntry id="51dd-461e-1657-1017" name="Grey Knights Land Raider Redeemer" hidden="false"/>
+    <categoryEntry id="88ad-5f29-ba09-9427" name="Grey Knights Razorback" hidden="false"/>
+    <categoryEntry id="5ced-f445-91c2-a55e" name="Grey Knights Rhino" hidden="false"/>
+    <categoryEntry id="82f-4771-c58e-1755" name="Grey Knights Stormhawk Interceptor" hidden="false"/>
+    <categoryEntry id="54b8-5bba-f749-e5ef" name="Grey Knights Stormraven Gunship" hidden="false"/>
+    <categoryEntry id="99eb-b003-79ba-7d46" name="Grey Knights Stormtalon Gunship" hidden="false"/>
+    <categoryEntry id="f580-2968-19f3-1320" name="Grey Knights Thunderhawk Gunship" hidden="false"/>
+    <categoryEntry id="33d4-b50a-18e8-16e8" name="Grey Knights Venerable Dreadnought" hidden="false"/>
+    <categoryEntry id="b7d3-6b00-c657-ebd7" name="Interceptor Squad" hidden="false"/>
+    <categoryEntry id="77b6-bfe8-648b-9fb4" name="Kaldor Draigo" hidden="false"/>
+    <categoryEntry id="3741-4bcf-f67e-1942" name="Land Raider Banisher" hidden="false"/>
+    <categoryEntry id="8083-7b7a-c9d7-fd31" name="Nemesis Dreadknight" hidden="false"/>
+    <categoryEntry id="9020-9fb5-8ef8-5ad4" name="Paladin Squad" hidden="false"/>
+    <categoryEntry id="8084-5bdd-7c6-bae4" name="Purgation Squad" hidden="false"/>
+    <categoryEntry id="67f8-444-b8b7-ad0" name="Purifier Squad" hidden="false"/>
+    <categoryEntry id="5bc8-a8b7-1c69-9043" name="Servitors" hidden="false"/>
+    <categoryEntry id="103f-a8cd-8c1f-24df" name="Strike Squad" hidden="false"/>
+    <categoryEntry id="4c57-a2d1-fe45-4ec1" name="Grey Knights Dreadnought [Legends]" hidden="false"/>
+    <categoryEntry id="6ee2-b8d8-f50b-67e3" name="Grey Knights Relic Razorback [Legends]" hidden="false"/>
+  </categoryEntries>
+  <entryLinks>
+    <entryLink id="8421-ca98-c324-ec3a" name="Brother-Captain" hidden="false" collective="false" import="true" targetId="dce9-6eb4-fa33-e869" type="selectionEntry"/>
+    <entryLink id="1712-989f-bbec-8109" name="Brother-Captain Stern" hidden="false" collective="false" import="true" targetId="aec2-ded6-fa0-3b75" type="selectionEntry"/>
+    <entryLink id="b391-1ca8-ca39-ece7" name="Brotherhood Champion" hidden="false" collective="false" import="true" targetId="2c81-4e74-8707-3117" type="selectionEntry"/>
+    <entryLink id="47d8-1a0a-e584-991" name="Brotherhood Chaplain" hidden="false" collective="false" import="true" targetId="b9b1-d698-1e98-da45" type="selectionEntry"/>
+    <entryLink id="eb42-25e1-cb7-81e0" name="Brotherhood Librarian" hidden="false" collective="false" import="true" targetId="5412-1f01-b7cc-bf12" type="selectionEntry"/>
+    <entryLink id="19bb-564d-866d-ff13" name="Brotherhood Techmarine" hidden="false" collective="false" import="true" targetId="f667-5267-f241-37" type="selectionEntry"/>
+    <entryLink id="1462-a777-45ab-a8b5" name="Brotherhood Terminator Squad" hidden="false" collective="false" import="true" targetId="a037-a89c-f59f-8b1e" type="selectionEntry"/>
+    <entryLink id="5c7b-487d-a534-77bd" name="Castellan Crowe" hidden="false" collective="false" import="true" targetId="9ddb-760d-8cf7-1c8a" type="selectionEntry"/>
+    <entryLink id="a304-8dfa-851c-b53d" name="Grand Master" hidden="false" collective="false" import="true" targetId="1a56-706b-a8f1-631a" type="selectionEntry"/>
+    <entryLink id="3066-9274-c887-86b" name="Grand Master in Nemesis Dreadknight" hidden="false" collective="false" import="true" targetId="3625-f9f1-122b-bf9d" type="selectionEntry"/>
+    <entryLink id="e3ba-ed19-bc91-81ee" name="Grand Master Voldus" hidden="false" collective="false" import="true" targetId="7256-bb3a-3e79-31fe" type="selectionEntry"/>
+    <entryLink id="99b4-6a62-b540-e864" name="Grey Knights Land Raider" hidden="false" collective="false" import="true" targetId="512d-b972-911e-4cac" type="selectionEntry"/>
+    <entryLink id="ed2d-a39d-c9e1-7e2e" name="Grey Knights Land Raider Crusader" hidden="false" collective="false" import="true" targetId="4c63-cca-8d26-6330" type="selectionEntry"/>
+    <entryLink id="8d8f-b8f9-8344-ef40" name="Grey Knights Land Raider Redeemer" hidden="false" collective="false" import="true" targetId="ada7-eb0b-c920-d77f" type="selectionEntry"/>
+    <entryLink id="9d6b-4332-27c3-c669" name="Grey Knights Razorback" hidden="false" collective="false" import="true" targetId="841f-98b-fbf3-c8ee" type="selectionEntry"/>
+    <entryLink id="41e6-9a15-f40e-149f" name="Grey Knights Rhino" hidden="false" collective="false" import="true" targetId="5ffd-f698-a1bb-fba7" type="selectionEntry"/>
+    <entryLink id="6906-148b-2d4a-f6cd" name="Grey Knights Stormhawk Interceptor" hidden="false" collective="false" import="true" targetId="fa-e288-2107-d22e" type="selectionEntry"/>
+    <entryLink id="9ad4-5c9e-4d7d-8ffd" name="Grey Knights Stormraven Gunship" hidden="false" collective="false" import="true" targetId="2efe-459b-9562-e7a9" type="selectionEntry"/>
+    <entryLink id="98a2-a561-b183-56a" name="Grey Knights Stormtalon Gunship" hidden="false" collective="false" import="true" targetId="84ac-b9ea-921f-9082" type="selectionEntry"/>
+    <entryLink id="b24d-be83-c5fe-d3fc" name="Grey Knights Venerable Dreadnought" hidden="false" collective="false" import="true" targetId="bd43-b303-66e0-4c10" type="selectionEntry"/>
+    <entryLink id="a53-5d6c-8148-4393" name="Interceptor Squad" hidden="false" collective="false" import="true" targetId="d9f7-71b7-8e67-7f44" type="selectionEntry"/>
+    <entryLink id="c945-9a85-5ea3-2142" name="Kaldor Draigo" hidden="false" collective="false" import="true" targetId="7a19-5235-692b-320d" type="selectionEntry"/>
+    <entryLink id="db7e-ce0-7ace-dc10" name="Land Raider Banisher" hidden="false" collective="false" import="true" targetId="69d-a656-fde3-6c3e" type="selectionEntry"/>
+    <entryLink id="9342-1cf-b2ab-b143" name="Nemesis Dreadknight" hidden="false" collective="false" import="true" targetId="5458-a458-c51d-c4e9" type="selectionEntry"/>
+    <entryLink id="1e9b-5681-eaf7-5e08" name="Paladin Squad" hidden="false" collective="false" import="true" targetId="6528-4634-c2cf-2840" type="selectionEntry"/>
+    <entryLink id="b257-3749-9bb2-4d4d" name="Grey Knights Thunderhawk Gunship" hidden="false" collective="false" import="true" targetId="8989-2fd2-4d29-e795" type="selectionEntry"/>
+    <entryLink id="8440-8405-d8ce-1592" name="Purgation Squad" hidden="false" collective="false" import="true" targetId="e8ad-bd40-5952-6859" type="selectionEntry"/>
+    <entryLink id="9893-e746-2796-740" name="Purifier Squad" hidden="false" collective="false" import="true" targetId="8865-df22-1629-bf02" type="selectionEntry"/>
+    <entryLink id="52b1-79b1-5bc6-575e" name="Servitors" hidden="false" collective="false" import="true" targetId="35ed-7890-6c56-18b7" type="selectionEntry"/>
+    <entryLink id="45ef-125c-ae4f-394d" name="Strike Squad" hidden="false" collective="false" import="true" targetId="d81f-c9ac-e338-ba37" type="selectionEntry"/>
+    <entryLink id="b859-7064-3a1e-1577" name="Detachment" hidden="false" collective="false" import="true" targetId="c05f-e67a-d2db-b3de" type="selectionEntry"/>
+    <entryLink id="b234-2a9e-174d-90b3" name="Grey Knights Relic Razorback [Legends]" hidden="false" collective="false" import="true" targetId="54f0-4b3f-3abe-081b" type="selectionEntry"/>
+    <entryLink id="4bb5-c50e-a835-38d1" name="Grey Knights Dreadnought [Legends]" hidden="false" collective="false" import="true" targetId="28d0-5a52-501a-441d" type="selectionEntry"/>
+    <entryLink id="e4b-7fa2-e394-baff" name="Show/Hide Options" hidden="false" collective="false" import="true" targetId="e8ef-836a-a9d1-901d" type="selectionEntry">
+      <entryLinks>
+        <entryLink id="537-702c-e58c-86a3" name="Show Agents of the Imperium" hidden="false" collective="false" import="true" targetId="e08b-2448-5606-fefb" type="selectionEntry"/>
+        <entryLink id="e981-3288-d103-387d" name="Show Imperial Knights" hidden="false" collective="false" import="true" targetId="e82c-6f8c-2b97-a287" type="selectionEntry"/>
+        <entryLink id="e48a-8350-26a3-9971" name="Show Titans" hidden="false" collective="false" import="true" targetId="f26b-79db-80e0-3a3b" type="selectionEntry"/>
+      </entryLinks>
+    </entryLink>
+  </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry type="model" import="true" name="Brother-Captain" hidden="false" id="dce9-6eb4-fa33-e869">
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="90"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="71ac-a100-1ec8-14e9" id="5012-310-4cac-e45b" primary="false" name="Brother-Captain"/>
-        <categoryLink targetId="740a-892c-8958-defa" id="df4b-5002-ce2-f36f" primary="false" name="Terminator"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="bee0-3d2f-b6c2-623f" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="d839-fd82-6a0f-cf68" primary="false" name="Psyker"/>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="9460-79cf-6237-6c1" primary="false" name="Infantry"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="50ad-8fb5-a7e5-baf7" primary="false" name="Imperium"/>
-        <categoryLink targetId="9cfd-1c32-585f-7d5c" id="644f-e76b-ecac-516e" primary="true" name="Character"/>
-      </categoryLinks>
+    <selectionEntry id="dce9-6eb4-fa33-e869" name="Brother-Captain" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile name="Brother-Captain" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="55b0-f49b-74d6-e55f">
+        <profile id="55b0-f49b-74d6-e55f" name="Brother-Captain" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">5&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">5</characteristic>
@@ -30,132 +89,46 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
           </characteristics>
         </profile>
-        <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="e1f9-80b5-6bc7-21f3">
+        <profile id="e1f9-80b5-6bc7-21f3" name="Leader" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
 ■ Brotherhood Terminator Squad
 ■ Paladin Squad</characteristic>
           </characteristics>
         </profile>
-        <profile name="Empyric Amplification (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="3f64-f896-c54f-7fea">
+        <profile id="3f64-f896-c54f-7fea" name="Empyric Amplification (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, Psychic weapons equipped by models in that unit have the [SUSTAINED HITS 1] ability.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Focused Mind (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="53db-1bc6-da94-f8e9">
+        <profile id="53db-1bc6-da94-f8e9" name="Focused Mind (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model makes an attack with a Psychic weapon, you can re-roll the Wound roll.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Leader" hidden="false" type="rule" id="b773-10b6-7cd6-ddeb" targetId="b4dd-3e1f-41cb-218f"/>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="4e1d-9c76-976f-4395" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Invulnerable Save (4+)" hidden="false" type="profile" id="5c10-dc0-a977-a135" targetId="df6-e949-835b-ad0d"/>
+        <infoLink id="b773-10b6-7cd6-ddeb" name="Leader" hidden="false" targetId="b4dd-3e1f-41cb-218f" type="rule"/>
+        <infoLink id="4e1d-9c76-976f-4395" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="5c10-dc0-a977-a135" name="Invulnerable Save (4+)" hidden="false" targetId="df6-e949-835b-ad0d" type="profile"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Weapon Choice" hidden="false" id="20a2-ba8f-784c-3bf" defaultSelectionEntryId="26b7-e7cf-33d8-9abe">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Psycannon" hidden="false" id="5d2c-27fb-8ec3-bb05">
-              <infoLinks>
-                <infoLink name="Psychic" hidden="false" type="rule" id="56db-e59a-2603-d2e9" targetId="e9c4-2bb8-12ee-cd1b"/>
-              </infoLinks>
-              <profiles>
-                <profile name="Psycannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="5cba-f6eb-aabb-c19">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Incinerator" hidden="false" id="da68-aa2c-9e7c-3ca2">
-              <profiles>
-                <profile name="Incinerator" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="5617-1390-33d3-3402">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Torrent</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink name="Ignores Cover" hidden="false" type="rule" id="278a-18aa-6f2d-fa4d" targetId="4640-43e7-30b-215a"/>
-                <infoLink name="Torrent" hidden="false" type="rule" id="7505-64f5-5a1a-1a28" targetId="5edf-d619-23e0-9b56"/>
-              </infoLinks>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Psilencer" hidden="false" id="70a0-b88a-6d05-3706">
-              <profiles>
-                <profile name="Psilencer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="90da-10ea-b155-59e0">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic, Sustained Hits 1</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink name="Sustained Hits" hidden="false" type="rule" id="4c93-67d6-2af8-4fbe" targetId="1897-c22c-9597-12b1">
-                  <modifiers>
-                    <modifier type="append" value="1" field="name"/>
-                  </modifiers>
-                </infoLink>
-                <infoLink name="Psychic" hidden="false" type="rule" id="5fae-a577-ba9a-82c7" targetId="e9c4-2bb8-12ee-cd1b"/>
-              </infoLinks>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="26b7-e7cf-33d8-9abe">
-              <profiles>
-                <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="2f3e-caff-ee9d-f7e0">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink name="Rapid Fire" hidden="false" type="rule" id="ae5a-ad95-234c-b716" targetId="c5c8-8b58-b8b6-7786">
-                  <modifiers>
-                    <modifier type="append" value="2" field="name"/>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-              </constraints>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="91fc-5d4d-70a1-955f"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b66e-ec0f-231-9d5f"/>
-          </constraints>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <categoryLinks>
+        <categoryLink id="5012-310-4cac-e45b" name="Brother-Captain" hidden="false" targetId="71ac-a100-1ec8-14e9" primary="false"/>
+        <categoryLink id="df4b-5002-ce2-f36f" name="Terminator" hidden="false" targetId="740a-892c-8958-defa" primary="false"/>
+        <categoryLink id="bee0-3d2f-b6c2-623f" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="d839-fd82-6a0f-cf68" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="9460-79cf-6237-6c1" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="false"/>
+        <categoryLink id="50ad-8fb5-a7e5-baf7" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="644f-e76b-ecac-516e" name="Character" hidden="false" targetId="9cfd-1c32-585f-7d5c" primary="true"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="16ba-fe2c-293d-f55d" collective="true">
+        <selectionEntry id="16ba-fe2c-293d-f55d" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
           </constraints>
           <profiles>
-            <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="5259-49ef-17f-db0a">
+            <profile id="5259-49ef-17f-db0a" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                 <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
@@ -168,31 +141,131 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Psychic" hidden="false" type="rule" id="7b40-821-225-87ef" targetId="e9c4-2bb8-12ee-cd1b"/>
+            <infoLink id="7b40-821-225-87ef" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="20a2-ba8f-784c-3bf" name="Weapon Choice" hidden="false" collective="false" import="false" defaultSelectionEntryId="26b7-e7cf-33d8-9abe">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91fc-5d4d-70a1-955f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b66e-ec0f-231-9d5f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5d2c-27fb-8ec3-bb05" name="Psycannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="5cba-f6eb-aabb-c19" name="Psycannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="56db-e59a-2603-d2e9" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="da68-aa2c-9e7c-3ca2" name="Incinerator" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="5617-1390-33d3-3402" name="Incinerator" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Torrent</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="278a-18aa-6f2d-fa4d" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+                <infoLink id="7505-64f5-5a1a-1a28" name="Torrent" hidden="false" targetId="5edf-d619-23e0-9b56" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="70a0-b88a-6d05-3706" name="Psilencer" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="90da-10ea-b155-59e0" name="Psilencer" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic, Sustained Hits 1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="4c93-67d6-2af8-4fbe" name="Sustained Hits" hidden="false" targetId="1897-c22c-9597-12b1" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value="1"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="5fae-a577-ba9a-82c7" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="26b7-e7cf-33d8-9abe" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="2f3e-caff-ee9d-f7e0" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="ae5a-ad95-234c-b716" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value="2"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
-        <entryLink import="true" name="Teleport Strike Force" hidden="false" type="selectionEntryGroup" id="4071-afce-23e1-75ca" targetId="c440-b056-f09a-c88a"/>
-        <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="9cf4-4ded-1e84-1743" targetId="beae-4593-3686-1672"/>
+        <entryLink id="4071-afce-23e1-75ca" name="Teleport Strike Force" hidden="false" collective="false" import="true" targetId="c440-b056-f09a-c88a" type="selectionEntryGroup"/>
+        <entryLink id="9cf4-4ded-1e84-1743" name="Warlord" hidden="false" collective="false" import="true" targetId="beae-4593-3686-1672" type="selectionEntry"/>
       </entryLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Brother-Captain Stern" hidden="false" id="aec2-ded6-fa0-3b75">
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="90"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="90.0"/>
       </costs>
-      <categoryLinks>
-        <categoryLink targetId="4f3a-f0f7-6647-348d" id="10e1-4f9b-111b-c14c" primary="true" name="Epic Hero"/>
-        <categoryLink targetId="9cfd-1c32-585f-7d5c" id="9d14-6548-12a4-5079" primary="false" name="Character"/>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="15cb-585f-4b68-fd4f" primary="false" name="Infantry"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="b53-a6f4-e44-1e53" primary="false" name="Imperium"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="84e0-4842-7a14-5b33" primary="false" name="Psyker"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="8836-847c-cfbe-8883" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="740a-892c-8958-defa" id="20d2-465d-f6ed-8971" primary="false" name="Terminator"/>
-        <categoryLink targetId="9e54-c14b-9ec9-e387" id="22e6-efcd-9b93-2cb6" primary="false" name="Brother-Captain Stern"/>
-      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry id="aec2-ded6-fa0-3b75" name="Brother-Captain Stern" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile name="Brother-Captain Stern" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="1c30-21c5-624d-cec9">
+        <profile id="1c30-21c5-624d-cec9" name="Brother-Captain Stern" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">5&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">5</characteristic>
@@ -202,37 +275,47 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
           </characteristics>
         </profile>
-        <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="7359-1f53-a51b-fb40">
+        <profile id="7359-1f53-a51b-fb40" name="Leader" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
 ■ Brotherhood Terminator Squad
 ■ Paladin Squad</characteristic>
           </characteristics>
         </profile>
-        <profile name="Exemplar of the Silvered Host" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="24f5-4ea1-bbc0-fc59">
+        <profile id="24f5-4ea1-bbc0-fc59" name="Exemplar of the Silvered Host" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, each time a model in that unit makes a melee attack, on a Critical Wound, the target suffers 1 mortal wound in addition to any normal damage.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Strands of Fate (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="186a-f980-321d-d883">
+        <profile id="186a-f980-321d-d883" name="Strands of Fate (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">The first time this model is destroyed, roll one D6 at the end of the phase. On a 2+, set this model back up on the battlefield as close as possible to where it was destroyed and not within Engagement Range of any enemy units, with its full wounds remaining.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Leader" hidden="false" type="rule" id="9ea3-9c24-9f8d-78e" targetId="b4dd-3e1f-41cb-218f"/>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="64bc-82bf-52d3-2541" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Invulnerable Save (4+)" hidden="false" type="profile" id="e6d0-ebde-69a5-a757" targetId="df6-e949-835b-ad0d"/>
+        <infoLink id="9ea3-9c24-9f8d-78e" name="Leader" hidden="false" targetId="b4dd-3e1f-41cb-218f" type="rule"/>
+        <infoLink id="64bc-82bf-52d3-2541" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="e6d0-ebde-69a5-a757" name="Invulnerable Save (4+)" hidden="false" targetId="df6-e949-835b-ad0d" type="profile"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="10e1-4f9b-111b-c14c" name="Epic Hero" hidden="false" targetId="4f3a-f0f7-6647-348d" primary="true"/>
+        <categoryLink id="9d14-6548-12a4-5079" name="Character" hidden="false" targetId="9cfd-1c32-585f-7d5c" primary="false"/>
+        <categoryLink id="15cb-585f-4b68-fd4f" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="false"/>
+        <categoryLink id="b53-a6f4-e44-1e53" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="84e0-4842-7a14-5b33" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="8836-847c-cfbe-8883" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="20d2-465d-f6ed-8971" name="Terminator" hidden="false" targetId="740a-892c-8958-defa" primary="false"/>
+        <categoryLink id="22e6-efcd-9b93-2cb6" name="Brother-Captain Stern" hidden="false" targetId="9e54-c14b-9ec9-e387" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Nemesis Force Sword" hidden="false" id="1b42-d922-74f0-c474" collective="true">
+        <selectionEntry id="1b42-d922-74f0-c474" name="Nemesis Force Sword" hidden="false" collective="true" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
           </constraints>
           <profiles>
-            <profile name="Nemesis Force Sword" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="7fff-ba8f-94c-dac">
+            <profile id="7fff-ba8f-94c-dac" name="Nemesis Force Sword" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                 <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
@@ -245,12 +328,19 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Psychic" hidden="false" type="rule" id="8daf-75fb-33f0-1d98" targetId="e9c4-2bb8-12ee-cd1b"/>
+            <infoLink id="8daf-75fb-33f0-1d98" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="5a29-5086-d86-9553">
+        <selectionEntry id="5a29-5086-d86-9553" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11a3-8954-73c5-f558" type="min"/>
+          </constraints>
           <profiles>
-            <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="6c37-7268-6ab-f038">
+            <profile id="6c37-7268-6ab-f038" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -263,36 +353,27 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Rapid Fire" hidden="false" type="rule" id="7ef7-11a7-3f4c-baf0" targetId="c5c8-8b58-b8b6-7786">
+            <infoLink id="7ef7-11a7-3f4c-baf0" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
               <modifiers>
-                <modifier type="append" value="2" field="name"/>
+                <modifier type="append" field="name" value="2"/>
               </modifiers>
             </infoLink>
           </infoLinks>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="11a3-8954-73c5-f558"/>
-          </constraints>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="20d3-9bd5-ea7-2688" targetId="beae-4593-3686-1672"/>
+        <entryLink id="20d3-9bd5-ea7-2688" name="Warlord" hidden="false" collective="false" import="true" targetId="beae-4593-3686-1672" type="selectionEntry"/>
       </entryLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Brotherhood Champion" hidden="false" id="2c81-4e74-8707-3117">
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="80"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="90.0"/>
       </costs>
-      <categoryLinks>
-        <categoryLink targetId="9cfd-1c32-585f-7d5c" id="5d57-34e6-3e82-c932" primary="true" name="Character"/>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="87b8-c4bf-126e-c893" primary="false" name="Infantry"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="bd01-ae3a-8804-56f1" primary="false" name="Psyker"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="6be9-bebe-993a-c05a" primary="false" name="Imperium"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="97bb-e9b6-41bd-ade9" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="c427-b327-40a0-a401" id="2bd5-bd1d-9831-5fb4" primary="false" name="Brotherhood Champion"/>
-      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry id="2c81-4e74-8707-3117" name="Brotherhood Champion" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile name="Brotherhood Champion" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="1072-460a-9247-6862">
+        <profile id="1072-460a-9247-6862" name="Brotherhood Champion" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">6&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">4</characteristic>
@@ -302,38 +383,46 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
           </characteristics>
         </profile>
-        <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="6201-69fa-9b1f-ef80">
+        <profile id="6201-69fa-9b1f-ef80" name="Leader" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
 ■ Purgation Squad
 ■ Strike Squad</characteristic>
           </characteristics>
         </profile>
-        <profile name="Ethereal Castigation (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="4020-4496-e5f3-62fd">
+        <profile id="4020-4496-e5f3-62fd" name="Ethereal Castigation (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, models in that unit have the Fights First ability.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Martial Fury" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="cc8f-6b40-8152-671f">
+        <profile id="cc8f-6b40-8152-671f" name="Martial Fury" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model makes a melee attack that targets a Character unit, you can re-roll the Hit roll and you can re-roll the Wound roll.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Leader" hidden="false" type="rule" id="4740-2ab7-4c53-4e37" targetId="b4dd-3e1f-41cb-218f"/>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="36b8-36f5-d613-ca9e" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Fights First" hidden="false" type="rule" id="4f48-4dcb-6d3e-72e9" targetId="24-c886-e8ba-5a89"/>
-        <infoLink name="Invulnerable Save (4+)" hidden="false" type="profile" id="40ed-1437-38dd-6487" targetId="df6-e949-835b-ad0d"/>
+        <infoLink id="4740-2ab7-4c53-4e37" name="Leader" hidden="false" targetId="b4dd-3e1f-41cb-218f" type="rule"/>
+        <infoLink id="36b8-36f5-d613-ca9e" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="4f48-4dcb-6d3e-72e9" name="Fights First" hidden="false" targetId="24-c886-e8ba-5a89" type="rule"/>
+        <infoLink id="40ed-1437-38dd-6487" name="Invulnerable Save (4+)" hidden="false" targetId="df6-e949-835b-ad0d" type="profile"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5d57-34e6-3e82-c932" name="Character" hidden="false" targetId="9cfd-1c32-585f-7d5c" primary="true"/>
+        <categoryLink id="87b8-c4bf-126e-c893" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="false"/>
+        <categoryLink id="bd01-ae3a-8804-56f1" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="6be9-bebe-993a-c05a" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="97bb-e9b6-41bd-ade9" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="2bd5-bd1d-9831-5fb4" name="Brotherhood Champion" hidden="false" targetId="c427-b327-40a0-a401" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="e4f1-7c06-108f-dda3" collective="true">
+        <selectionEntry id="e4f1-7c06-108f-dda3" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
           </constraints>
           <profiles>
-            <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="dc6c-486b-c19-71a1">
+            <profile id="dc6c-486b-c19-71a1" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                 <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
@@ -346,13 +435,20 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Psychic" hidden="false" type="rule" id="197a-4bfd-42c3-8f38" targetId="e9c4-2bb8-12ee-cd1b"/>
-            <infoLink name="Precision" hidden="false" type="rule" id="383-ed8e-fe7e-532c" targetId="9143-31ae-e0a6-6007"/>
+            <infoLink id="197a-4bfd-42c3-8f38" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+            <infoLink id="383-ed8e-fe7e-532c" name="Precision" hidden="false" targetId="9143-31ae-e0a6-6007" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="2ff3-9667-2277-c8e6">
+        <selectionEntry id="2ff3-9667-2277-c8e6" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11a3-8954-73c5-f558" type="min"/>
+          </constraints>
           <profiles>
-            <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="1f4-8e4d-87ba-5d6f">
+            <profile id="1f4-8e4d-87ba-5d6f" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -365,38 +461,28 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Rapid Fire" hidden="false" type="rule" id="3aaa-5f74-fcfd-238e" targetId="c5c8-8b58-b8b6-7786">
+            <infoLink id="3aaa-5f74-fcfd-238e" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
               <modifiers>
-                <modifier type="append" value="2" field="name"/>
+                <modifier type="append" field="name" value="2"/>
               </modifiers>
             </infoLink>
           </infoLinks>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="11a3-8954-73c5-f558"/>
-          </constraints>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink import="true" name="Teleport Strike Force" hidden="false" type="selectionEntryGroup" id="4ef6-82e7-5d90-dfa9" targetId="c440-b056-f09a-c88a"/>
-        <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="79a5-e051-9aec-325d" targetId="beae-4593-3686-1672"/>
+        <entryLink id="4ef6-82e7-5d90-dfa9" name="Teleport Strike Force" hidden="false" collective="false" import="true" targetId="c440-b056-f09a-c88a" type="selectionEntryGroup"/>
+        <entryLink id="79a5-e051-9aec-325d" name="Warlord" hidden="false" collective="false" import="true" targetId="beae-4593-3686-1672" type="selectionEntry"/>
       </entryLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Brotherhood Chaplain" hidden="false" id="b9b1-d698-1e98-da45">
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="75"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="80.0"/>
       </costs>
-      <categoryLinks>
-        <categoryLink targetId="ebf4-5ffe-19e7-c6c7" id="d184-1a1e-4a50-eaa5" primary="false" name="Brotherhood Chaplain"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="45e3-5602-6eb4-15c4" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="740a-892c-8958-defa" id="d42a-4405-7a42-759e" primary="false" name="Terminator"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="9ab5-6549-8a95-e62a" primary="false" name="Psyker"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="ca41-e9bb-f0b9-b81b" primary="false" name="Imperium"/>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="1bbe-350b-e827-901a" primary="false" name="Infantry"/>
-        <categoryLink targetId="9cfd-1c32-585f-7d5c" id="a133-7aea-d480-b9de" primary="true" name="Character"/>
-      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry id="b9b1-d698-1e98-da45" name="Brotherhood Chaplain" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile name="Brotherhood Chaplain" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="1f7b-a5fe-f980-70e7">
+        <profile id="1f7b-a5fe-f980-70e7" name="Brotherhood Chaplain" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">5&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">5</characteristic>
@@ -406,17 +492,17 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
           </characteristics>
         </profile>
-        <profile name="Words of Power (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="82-db07-19c0-1f1b">
+        <profile id="82-db07-19c0-1f1b" name="Words of Power (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, each time a model in that unit makes a melee attack, add 1 to the Wound roll.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Dread Bearing (Aura)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="8d73-2ecd-2b3c-3f18">
+        <profile id="8d73-2ecd-2b3c-3f18" name="Dread Bearing (Aura)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While an enemy unit is within 6&quot; of this model, each time that unit takes a Battle-shock or Leadership test, subtract 1 from that test</characteristic>
           </characteristics>
         </profile>
-        <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="82ae-190e-a811-610">
+        <profile id="82ae-190e-a811-610" name="Leader" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
 ■ Brotherhood Terminator Squad
@@ -425,14 +511,27 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Leader" hidden="false" type="rule" id="6f29-bc30-ecca-c1a1" targetId="b4dd-3e1f-41cb-218f"/>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="ce58-94f6-4b8f-3c7b" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Invulnerable Save (4+)" hidden="false" type="profile" id="7aae-62a1-b668-1" targetId="df6-e949-835b-ad0d"/>
+        <infoLink id="6f29-bc30-ecca-c1a1" name="Leader" hidden="false" targetId="b4dd-3e1f-41cb-218f" type="rule"/>
+        <infoLink id="ce58-94f6-4b8f-3c7b" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="7aae-62a1-b668-1" name="Invulnerable Save (4+)" hidden="false" targetId="df6-e949-835b-ad0d" type="profile"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d184-1a1e-4a50-eaa5" name="Brotherhood Chaplain" hidden="false" targetId="ebf4-5ffe-19e7-c6c7" primary="false"/>
+        <categoryLink id="45e3-5602-6eb4-15c4" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="d42a-4405-7a42-759e" name="Terminator" hidden="false" targetId="740a-892c-8958-defa" primary="false"/>
+        <categoryLink id="9ab5-6549-8a95-e62a" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="ca41-e9bb-f0b9-b81b" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="1bbe-350b-e827-901a" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="false"/>
+        <categoryLink id="a133-7aea-d480-b9de" name="Character" hidden="false" targetId="9cfd-1c32-585f-7d5c" primary="true"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="6fc3-5e9-2ebc-b8b8">
+        <selectionEntry id="6fc3-5e9-2ebc-b8b8" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11a3-8954-73c5-f558" type="min"/>
+          </constraints>
           <profiles>
-            <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="f268-aa7f-636c-9155">
+            <profile id="f268-aa7f-636c-9155" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -445,20 +544,23 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Rapid Fire" hidden="false" type="rule" id="dc46-6b8d-f333-4be0" targetId="c5c8-8b58-b8b6-7786">
+            <infoLink id="dc46-6b8d-f333-4be0" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
               <modifiers>
-                <modifier type="append" value="2" field="name"/>
+                <modifier type="append" field="name" value="2"/>
               </modifiers>
             </infoLink>
           </infoLinks>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="11a3-8954-73c5-f558"/>
-          </constraints>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Crozius Arcanum" hidden="false" id="4e88-c580-e5fa-ae6c">
+        <selectionEntry id="4e88-c580-e5fa-ae6c" name="Crozius Arcanum" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="845e-fc2d-7dd2-5199" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ac3-2723-69a2-66f" type="max"/>
+          </constraints>
           <profiles>
-            <profile name="Crozius Arcanum" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="5fa9-c9b2-336e-6d3c">
+            <profile id="5fa9-c9b2-336e-6d3c" name="Crozius Arcanum" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                 <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
@@ -470,32 +572,22 @@
               </characteristics>
             </profile>
           </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="845e-fc2d-7dd2-5199"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1ac3-2723-69a2-66f"/>
-          </constraints>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink import="true" name="Teleport Strike Force" hidden="false" type="selectionEntryGroup" id="bce8-46bb-af2e-7a00" targetId="c440-b056-f09a-c88a"/>
-        <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="8315-c234-f1b1-ace7" targetId="beae-4593-3686-1672"/>
+        <entryLink id="bce8-46bb-af2e-7a00" name="Teleport Strike Force" hidden="false" collective="false" import="true" targetId="c440-b056-f09a-c88a" type="selectionEntryGroup"/>
+        <entryLink id="8315-c234-f1b1-ace7" name="Warlord" hidden="false" collective="false" import="true" targetId="beae-4593-3686-1672" type="selectionEntry"/>
       </entryLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Brotherhood Librarian" hidden="false" id="5412-1f01-b7cc-bf12">
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="100"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="75.0"/>
       </costs>
-      <categoryLinks>
-        <categoryLink targetId="bd80-12a6-cd23-96c9" id="e65e-1274-e566-e150" primary="false" name="Brotherhood Librarian"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="28ac-c555-8833-2f85" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="1304-cd67-cb06-786b" primary="false" name="Imperium"/>
-        <categoryLink targetId="740a-892c-8958-defa" id="7d7c-768-b284-52bc" primary="false" name="Terminator"/>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="869-1b2d-6802-368d" primary="false" name="Infantry"/>
-        <categoryLink targetId="9cfd-1c32-585f-7d5c" id="35eb-1344-bdb9-45fa" primary="true" name="Character"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="8833-9c88-55a5-8616" primary="false" name="Psyker"/>
-      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry id="5412-1f01-b7cc-bf12" name="Brotherhood Librarian" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile name="Brotherhood Librarian" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="f05a-b020-dc82-24e">
+        <profile id="f05a-b020-dc82-24e" name="Brotherhood Librarian" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">5&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">5</characteristic>
@@ -505,37 +597,46 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
           </characteristics>
         </profile>
-        <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="3dec-ee8c-120d-4010">
+        <profile id="3dec-ee8c-120d-4010" name="Leader" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
 ■ Brotherhood Terminator Squad
 ■ Paladin Squad</characteristic>
           </characteristics>
         </profile>
-        <profile name="Sanctic Hood" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="9d41-eb97-8f61-fb85">
+        <profile id="9d41-eb97-8f61-fb85" name="Sanctic Hood" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, models in that unit have the Feel No Pain 4+ ability against Psychic Attacks.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Vortex of Doom (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="f49c-a3e0-29e8-7304">
+        <profile id="f49c-a3e0-29e8-7304" name="Vortex of Doom (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">In your Shooting phase, you can select one enemy unit within 18&quot; of and visible to this Psyker and roll one D6: on a 1, this Psyker’s unit suffers D6 mortal wounds; on a 2-5, that enemy unit suffers 2D3 mortal wounds; on a 6, that enemy unit suffers 2D6 mortal wounds.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Leader" hidden="false" type="rule" id="9270-81ea-8bba-31ee" targetId="b4dd-3e1f-41cb-218f"/>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="aabc-18b2-e696-ba9e" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Invulnerable Save (4+)" hidden="false" type="profile" id="b7b2-cc96-7c3e-d100" targetId="df6-e949-835b-ad0d"/>
+        <infoLink id="9270-81ea-8bba-31ee" name="Leader" hidden="false" targetId="b4dd-3e1f-41cb-218f" type="rule"/>
+        <infoLink id="aabc-18b2-e696-ba9e" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="b7b2-cc96-7c3e-d100" name="Invulnerable Save (4+)" hidden="false" targetId="df6-e949-835b-ad0d" type="profile"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e65e-1274-e566-e150" name="Brotherhood Librarian" hidden="false" targetId="bd80-12a6-cd23-96c9" primary="false"/>
+        <categoryLink id="28ac-c555-8833-2f85" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="1304-cd67-cb06-786b" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="7d7c-768-b284-52bc" name="Terminator" hidden="false" targetId="740a-892c-8958-defa" primary="false"/>
+        <categoryLink id="869-1b2d-6802-368d" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="false"/>
+        <categoryLink id="35eb-1344-bdb9-45fa" name="Character" hidden="false" targetId="9cfd-1c32-585f-7d5c" primary="true"/>
+        <categoryLink id="8833-9c88-55a5-8616" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="fffe-abc5-ac4f-6eda" collective="true">
+        <selectionEntry id="fffe-abc5-ac4f-6eda" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
           </constraints>
           <profiles>
-            <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="8404-b7bc-4d0f-6136">
+            <profile id="8404-b7bc-4d0f-6136" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                 <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
@@ -548,12 +649,19 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Psychic" hidden="false" type="rule" id="db4-2bff-fa0f-657" targetId="e9c4-2bb8-12ee-cd1b"/>
+            <infoLink id="db4-2bff-fa0f-657" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Purge Soul" hidden="false" id="3aa5-b3f3-8ec2-8559">
+        <selectionEntry id="3aa5-b3f3-8ec2-8559" name="Purge Soul" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b36a-b19b-ead2-aa70" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d24d-bcc3-b20f-ad46" type="min"/>
+          </constraints>
           <profiles>
-            <profile name="➤ Purge Soul - Witchfire" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="3820-e568-e53-96f2">
+            <profile id="3820-e568-e53-96f2" name="➤ Purge Soul - Witchfire" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
@@ -564,7 +672,7 @@
                 <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
               </characteristics>
             </profile>
-            <profile name="➤ Purge Soul - Focused Witchfire" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="65d8-79ca-e784-b480">
+            <profile id="65d8-79ca-e784-b480" name="➤ Purge Soul - Focused Witchfire" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
@@ -576,23 +684,29 @@
               </characteristics>
             </profile>
           </profiles>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b36a-b19b-ead2-aa70"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d24d-bcc3-b20f-ad46"/>
-          </constraints>
           <infoLinks>
-            <infoLink name="Psychic" hidden="false" type="rule" id="7171-9d6f-574-c03d" targetId="e9c4-2bb8-12ee-cd1b"/>
-            <infoLink name="Precision" hidden="false" type="rule" id="efad-4c6e-5824-10ab" targetId="9143-31ae-e0a6-6007"/>
-            <infoLink name="Hazardous" hidden="false" type="rule" id="fd19-c75a-61ed-22e4" targetId="8367-374c-f87-c627"/>
+            <infoLink id="7171-9d6f-574-c03d" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+            <infoLink id="efad-4c6e-5824-10ab" name="Precision" hidden="false" targetId="9143-31ae-e0a6-6007" type="rule"/>
+            <infoLink id="fd19-c75a-61ed-22e4" name="Hazardous" hidden="false" targetId="8367-374c-f87-c627" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup name="Weapon Choice" hidden="false" id="8032-b82d-886c-13e0" defaultSelectionEntryId="f6ec-2a11-5ca6-344b">
+        <selectionEntryGroup id="8032-b82d-886c-13e0" name="Weapon Choice" hidden="false" collective="false" import="false" defaultSelectionEntryId="f6ec-2a11-5ca6-344b">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91fc-5d4d-70a1-955f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b66e-ec0f-231-9d5f" type="max"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="f6ec-2a11-5ca6-344b">
+            <selectionEntry id="f6ec-2a11-5ca6-344b" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+              </constraints>
               <profiles>
-                <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="2148-2720-3189-df67">
+                <profile id="2148-2720-3189-df67" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                   <characteristics>
                     <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                     <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -605,19 +719,19 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink name="Rapid Fire" hidden="false" type="rule" id="7235-e8b8-4ba9-ec1a" targetId="c5c8-8b58-b8b6-7786">
+                <infoLink id="7235-e8b8-4ba9-ec1a" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
                   <modifiers>
-                    <modifier type="append" value="2" field="name"/>
+                    <modifier type="append" field="name" value="2"/>
                   </modifiers>
                 </infoLink>
               </infoLinks>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-              </constraints>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Combi-Weapon" hidden="false" id="a0ce-78-c636-3bc6">
+            <selectionEntry id="a0ce-78-c636-3bc6" name="Combi-Weapon" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
-                <profile name="Combi-Weapon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="d680-44f9-1df9-8e42">
+                <profile id="d680-44f9-1df9-8e42" name="Combi-Weapon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                   <characteristics>
                     <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                     <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
@@ -630,45 +744,36 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink name="Anti-" hidden="false" type="rule" id="1819-3f3-340c-87db" targetId="4111-82e3-9444-e942">
+                <infoLink id="1819-3f3-340c-87db" name="Anti-" hidden="false" targetId="4111-82e3-9444-e942" type="rule">
                   <modifiers>
-                    <modifier type="append" value="Infantry 4+" field="name"/>
+                    <modifier type="append" field="name" value="Infantry 4+"/>
                   </modifiers>
                 </infoLink>
-                <infoLink name="Rapid Fire" hidden="false" type="rule" id="3316-52a7-caa2-7aab" targetId="c5c8-8b58-b8b6-7786">
+                <infoLink id="3316-52a7-caa2-7aab" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
                   <modifiers>
-                    <modifier type="append" value="1" field="name"/>
+                    <modifier type="append" field="name" value="1"/>
                   </modifiers>
                 </infoLink>
-                <infoLink name="Devastating Wounds" hidden="false" type="rule" id="e197-a5cc-eab9-1e10" targetId="be1e-ac8e-1e2c-3528"/>
+                <infoLink id="e197-a5cc-eab9-1e10" name="Devastating Wounds" hidden="false" targetId="be1e-ac8e-1e2c-3528" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="91fc-5d4d-70a1-955f"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b66e-ec0f-231-9d5f"/>
-          </constraints>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink import="true" name="Teleport Strike Force" hidden="false" type="selectionEntryGroup" id="3d2f-8d58-cc23-f964" targetId="c440-b056-f09a-c88a"/>
-        <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="2eae-325a-472b-94" targetId="beae-4593-3686-1672"/>
+        <entryLink id="3d2f-8d58-cc23-f964" name="Teleport Strike Force" hidden="false" collective="false" import="true" targetId="c440-b056-f09a-c88a" type="selectionEntryGroup"/>
+        <entryLink id="2eae-325a-472b-94" name="Warlord" hidden="false" collective="false" import="true" targetId="beae-4593-3686-1672" type="selectionEntry"/>
       </entryLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Brotherhood Techmarine" hidden="false" id="f667-5267-f241-37">
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="60"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="100.0"/>
       </costs>
-      <categoryLinks>
-        <categoryLink targetId="9cfd-1c32-585f-7d5c" id="1a39-d882-ebc2-5632" primary="true" name="Character"/>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="9f00-d932-561a-de05" primary="false" name="Infantry"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="406c-f893-f62-146d" primary="false" name="Psyker"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="74db-330c-298f-3ece" primary="false" name="Imperium"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="7e67-89b0-52df-5e63" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="c352-657f-d2cc-adcf" id="7f6d-2e95-89a8-4af7" primary="false" name="Brotherhood Techmarine"/>
-      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry id="f667-5267-f241-37" name="Brotherhood Techmarine" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile name="Brotherhood Techmarine" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="2e1f-f5d5-d4ff-f061">
+        <profile id="2e1f-f5d5-d4ff-f061" name="Brotherhood Techmarine" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">5&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">4</characteristic>
@@ -678,81 +783,49 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
           </characteristics>
         </profile>
-        <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="a0a4-1a94-df1f-ef4f">
+        <profile id="a0a4-1a94-df1f-ef4f" name="Leader" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
 ■ Servitors
 ■ Strike Squad</characteristic>
           </characteristics>
         </profile>
-        <profile name="Awaken the Machine Spirit" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="877c-7676-7032-ecd3">
+        <profile id="877c-7676-7032-ecd3" name="Awaken the Machine Spirit" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">In your Command phase, you can select one friendly GREY KNIGHTS VEHICLE model within 6&quot; of this model. Until the start of your next Command phase, each time that VEHICLE model makes an attack, add 1 to the Hit roll.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Omnissiah’s Blessing" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="f298-3658-77a2-5851">
+        <profile id="f298-3658-77a2-5851" name="Omnissiah’s Blessing" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">In your Command phase, you can select one friendly Grey Knights Vehicle model within 3&quot; of this model. That Vehicle model regains up to D3 lost wounds.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Techmarine" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="7750-f512-8316-e851">
+        <profile id="7750-f512-8316-e851" name="Techmarine" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is within 3&quot; of one or more friendly Grey Knights Vehicle units, unless it is leading a unit, this model has the Lone Operative ability</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Leader" hidden="false" type="rule" id="c2d8-8565-c5d5-e49e" targetId="b4dd-3e1f-41cb-218f"/>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="c43e-345d-bb6-9dd1" targetId="7cb5-dd6b-dd87-ad3b"/>
+        <infoLink id="c2d8-8565-c5d5-e49e" name="Leader" hidden="false" targetId="b4dd-3e1f-41cb-218f" type="rule"/>
+        <infoLink id="c43e-345d-bb6-9dd1" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Ranged Weapon" hidden="false" id="9fd1-cdfd-7fbd-70ef" defaultSelectionEntryId="3116-6dc9-27ee-97bb">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Boltgun" hidden="false" id="3116-6dc9-27ee-97bb">
-              <profiles>
-                <profile name="Boltgun" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="f239-3ccc-a7ed-a37a">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Bolt Pistol" hidden="false" id="24a3-f6c0-3ca7-ae59">
-              <profiles>
-                <profile name="Bolt Pistol" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="3510-76fc-5d-2f5e">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Pistol</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="97d7-70b-14be-968f"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="84ff-c335-6266-499b"/>
-          </constraints>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <categoryLinks>
+        <categoryLink id="1a39-d882-ebc2-5632" name="Character" hidden="false" targetId="9cfd-1c32-585f-7d5c" primary="true"/>
+        <categoryLink id="9f00-d932-561a-de05" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="false"/>
+        <categoryLink id="406c-f893-f62-146d" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="74db-330c-298f-3ece" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="7e67-89b0-52df-5e63" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="7f6d-2e95-89a8-4af7" name="Brotherhood Techmarine" hidden="false" targetId="c352-657f-d2cc-adcf" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Omnissian Power Axe" hidden="false" id="aa5-cfe9-83d9-250a">
+        <selectionEntry id="aa5-cfe9-83d9-250a" name="Omnissian Power Axe" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="babc-84e7-7d38-c82c"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6910-b067-f7d7-9c08"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="babc-84e7-7d38-c82c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6910-b067-f7d7-9c08" type="max"/>
           </constraints>
           <profiles>
-            <profile name="Omnissian Power Axe" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="59d5-7666-1edf-125e">
+            <profile id="59d5-7666-1edf-125e" name="Omnissian Power Axe" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                 <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
@@ -764,14 +837,17 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Flamer" hidden="false" id="78d0-de33-2a42-edef">
+        <selectionEntry id="78d0-de33-2a42-edef" name="Flamer" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f667-45a8-152-64c6"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8115-444-8ff9-7054"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f667-45a8-152-64c6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8115-444-8ff9-7054" type="max"/>
           </constraints>
           <profiles>
-            <profile name="Flamer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="462e-af68-3725-10ef">
+            <profile id="462e-af68-3725-10ef" name="Flamer" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
@@ -783,14 +859,17 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Plasma Cutter" hidden="false" id="3549-7e11-cc13-6991">
+        <selectionEntry id="3549-7e11-cc13-6991" name="Plasma Cutter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="edb0-5bd2-f6a-8ba4"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f094-62a7-d07f-d4c2"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edb0-5bd2-f6a-8ba4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f094-62a7-d07f-d4c2" type="max"/>
           </constraints>
           <profiles>
-            <profile name="➤ Plasma Cutter - standard" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="cf76-7725-98e1-d456">
+            <profile id="cf76-7725-98e1-d456" name="➤ Plasma Cutter - standard" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                 <characteristic name="A" typeId="2337-daa1-6682-b110">2</characteristic>
@@ -801,7 +880,7 @@
                 <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Extra Attacks</characteristic>
               </characteristics>
             </profile>
-            <profile name="➤ Plasma Cutter - supercharge" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="3bd0-22d0-6cad-cbbd">
+            <profile id="3bd0-22d0-6cad-cbbd" name="➤ Plasma Cutter - supercharge" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                 <characteristic name="A" typeId="2337-daa1-6682-b110">2</characteristic>
@@ -813,14 +892,17 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Servo-arms" hidden="false" id="56a2-d965-8a31-8eec">
+        <selectionEntry id="56a2-d965-8a31-8eec" name="Servo-arms" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a439-2174-ed6c-895c"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e724-9f3c-f519-bf7e"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a439-2174-ed6c-895c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e724-9f3c-f519-bf7e" type="max"/>
           </constraints>
           <profiles>
-            <profile name="Servo-arms" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="8f56-9025-c58b-b16">
+            <profile id="8f56-9025-c58b-b16" name="Servo-arms" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                 <characteristic name="A" typeId="2337-daa1-6682-b110">2</characteristic>
@@ -832,36 +914,75 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9fd1-cdfd-7fbd-70ef" name="Ranged Weapon" hidden="false" collective="false" import="false" defaultSelectionEntryId="3116-6dc9-27ee-97bb">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97d7-70b-14be-968f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84ff-c335-6266-499b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3116-6dc9-27ee-97bb" name="Boltgun" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="f239-3ccc-a7ed-a37a" name="Boltgun" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="24a3-f6c0-3ca7-ae59" name="Bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="3510-76fc-5d-2f5e" name="Bolt Pistol" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Pistol</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
-        <entryLink import="true" name="Teleport Strike Force" hidden="false" type="selectionEntryGroup" id="8221-d7ae-98a7-7bb7" targetId="c440-b056-f09a-c88a"/>
-        <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="4688-73ca-5595-3348" targetId="beae-4593-3686-1672"/>
+        <entryLink id="8221-d7ae-98a7-7bb7" name="Teleport Strike Force" hidden="false" collective="false" import="true" targetId="c440-b056-f09a-c88a" type="selectionEntryGroup"/>
+        <entryLink id="4688-73ca-5595-3348" name="Warlord" hidden="false" collective="false" import="true" targetId="beae-4593-3686-1672" type="selectionEntry"/>
       </entryLinks>
-    </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Brotherhood Terminator Squad" hidden="false" id="a037-a89c-f59f-8b1e">
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="210"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="60.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="a037-a89c-f59f-8b1e" name="Brotherhood Terminator Squad" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="set" value="420" field="51b2-306e-1021-d207">
+        <modifier type="set" field="51b2-306e-1021-d207" value="420">
           <conditions>
-            <condition type="atLeast" value="6" field="selections" scope="a037-a89c-f59f-8b1e" childId="model" shared="true"/>
+            <condition field="selections" scope="a037-a89c-f59f-8b1e" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
           </conditions>
         </modifier>
       </modifiers>
-      <categoryLinks>
-        <categoryLink targetId="e338-111e-d0c6-b687" id="9d95-2e93-1685-c8c6" primary="true" name="Battleline"/>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="86f5-5745-852-cee" primary="false" name="Infantry"/>
-        <categoryLink targetId="5a61-81ac-eb7c-a87e" id="b1a3-eea3-495b-20de" primary="false" name="Grenades"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="ff6d-4e99-9d83-68eb" primary="false" name="Psyker"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="744b-b162-910-70dd" primary="false" name="Imperium"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="927f-353a-80f5-4433" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="740a-892c-8958-defa" id="311f-74cb-9fa6-f53c" primary="false" name="Terminator"/>
-        <categoryLink targetId="cddf-ac1-4a0d-8e48" id="7277-5b39-d794-7af5" primary="false" name="Brotherhood Terminator Squad"/>
-      </categoryLinks>
       <profiles>
-        <profile name="Brotherhood Terminator Squad" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="28af-6e37-2f1f-93d2">
+        <profile id="28af-6e37-2f1f-93d2" name="Brotherhood Terminator Squad" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">5&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">5</characteristic>
@@ -871,294 +992,40 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">2</characteristic>
           </characteristics>
         </profile>
-        <profile name="Hammerhand (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="3ebb-9bbe-208-ac9c">
+        <profile id="3ebb-9bbe-208-ac9c" name="Hammerhand (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a model in this unit makes a Charge move, until the end of the turn, melee weapons equipped by models in this unit have the [LETHAL HITS] ability.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="8924-88a6-d109-fc61" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Invulnerable Save (4+)" hidden="false" type="profile" id="51b9-edbc-12d7-a878" targetId="a343-738-c273-4e13"/>
+        <infoLink id="8924-88a6-d109-fc61" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="51b9-edbc-12d7-a878" name="Invulnerable Save (4+)" hidden="false" targetId="a343-738-c273-4e13" type="profile"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Terminators (4-9)" hidden="false" id="2da-fe4-d745-7dda" defaultSelectionEntryId="f5c5-56fd-51ec-d1a6">
-          <selectionEntries>
-            <selectionEntry type="model" import="true" name="Terminator" hidden="false" id="f5c5-56fd-51ec-d1a6">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="261c-9752-7bd3-7bf2" collective="true">
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
-                  </constraints>
-                  <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="1205-b96b-bcfc-40c3">
-                      <characteristics>
-                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
-                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
-                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="fa00-da2b-3beb-431e" targetId="e9c4-2bb8-12ee-cd1b"/>
-                  </infoLinks>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="aa86-238b-9ca6-7504" collective="true">
-                  <profiles>
-                    <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="7b12-a858-6de3-4ee2">
-                      <characteristics>
-                        <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                        <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                        <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                        <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                        <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink name="Rapid Fire" hidden="false" type="rule" id="8a35-6814-4656-9c79" targetId="c5c8-8b58-b8b6-7786">
-                      <modifiers>
-                        <modifier type="append" value="2" field="name"/>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b77a-f8d6-ae23-1a1d"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-                  </constraints>
-                </selectionEntry>
-              </selectionEntries>
-              <constraints>
-                <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="ca99-81d5-43f8-de75"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="model" import="true" name="Terminator with Ancient&apos;s Banner" hidden="false" id="6215-3f01-f844-585">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="26c3-5023-9a33-4c8"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="3934-1e64-5a6a-8e54" collective="true">
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
-                  </constraints>
-                  <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="85b5-9fcc-d929-8477">
-                      <characteristics>
-                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
-                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
-                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="73b9-bf-a242-b68c" targetId="e9c4-2bb8-12ee-cd1b"/>
-                  </infoLinks>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Ancient&apos;s Banner" hidden="false" id="55ab-530-9b32-a5d0" collective="true">
-                  <profiles>
-                    <profile name="Ancient&apos;s Banner" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="1e79-d50f-92b3-4ce4">
-                      <characteristics>
-                        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Add 1 to the Objective Control characteristic of models in the bearer’s unit.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7ced-59bb-1646-d784"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1060-a780-b862-b87b"/>
-                  </constraints>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup name="Weapon Choice" hidden="false" id="c9a0-cf4e-fb96-6bf1" defaultSelectionEntryId="33b5-e668-d503-7039">
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="33b5-e668-d503-7039" collective="false">
-                      <profiles>
-                        <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="7bb3-feb-8824-b24">
-                          <characteristics>
-                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                            <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                            <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <infoLinks>
-                        <infoLink name="Rapid Fire" hidden="false" type="rule" id="2977-f794-39a0-c594" targetId="c5c8-8b58-b8b6-7786">
-                          <modifiers>
-                            <modifier type="append" value="2" field="name"/>
-                          </modifiers>
-                        </infoLink>
-                      </infoLinks>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="eaaa-819b-640a-c8a5"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="10ad-89fc-41f8-a5eb"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink import="true" name="Incinerator" hidden="false" type="selectionEntry" id="7114-8a85-9d3b-4361" targetId="17ed-2f7b-bf3a-3c94"/>
-                    <entryLink import="true" name="Psycannon" hidden="false" type="selectionEntry" id="a5bd-813-a8b5-e369" targetId="e520-9c7-d10c-897d"/>
-                    <entryLink import="true" name="Psilencer" hidden="false" type="selectionEntry" id="e5ca-411f-b028-403e" targetId="d526-d040-807c-34f6"/>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-            </selectionEntry>
-            <selectionEntry type="model" import="true" name="Terminator with Narthecium" hidden="false" id="22fd-3d1b-9957-2d5f">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="73f3-7268-a1f4-ccb0"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="29dd-35d3-910f-c1c4" collective="true">
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
-                  </constraints>
-                  <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="7ec2-c49e-ba02-c802">
-                      <characteristics>
-                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
-                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
-                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="e99d-16e3-a591-c0e1" targetId="e9c4-2bb8-12ee-cd1b"/>
-                  </infoLinks>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Narthecium" hidden="false" id="65d9-e2ef-776d-f579" collective="true">
-                  <profiles>
-                    <profile name="Narthecium" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="97ca-b4cb-c700-e6c2">
-                      <characteristics>
-                        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">In your Command phase, you can return 1 destroyed model (excluding Characters) to the bearer’s unit</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c970-d110-2a59-afb1"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ab3b-201b-e05e-1c22"/>
-                  </constraints>
-                </selectionEntry>
-              </selectionEntries>
-            </selectionEntry>
-            <selectionEntry type="model" import="true" name="Terminator with Heavy Weapon" hidden="false" id="77d3-d321-bb86-dabe">
-              <selectionEntryGroups>
-                <selectionEntryGroup name="Heavy Weapon" hidden="false" id="c1b7-ce3c-faf0-2090" defaultSelectionEntryId="c694-9e9d-faf1-87b7">
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="91fc-5d4d-70a1-955f"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b66e-ec0f-231-9d5f"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink import="true" name="Incinerator" hidden="false" type="selectionEntry" id="414-6fc2-8423-f86e" targetId="17ed-2f7b-bf3a-3c94"/>
-                    <entryLink import="true" name="Psilencer" hidden="false" type="selectionEntry" id="3ccf-db10-dc87-3038" targetId="d526-d040-807c-34f6"/>
-                    <entryLink import="true" name="Psycannon" hidden="false" type="selectionEntry" id="39bd-f647-4b4d-9494" targetId="e520-9c7-d10c-897d"/>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="702-d447-314b-a3f6"/>
-              </constraints>
-              <modifiers>
-                <modifier type="set" value="2" field="702-d447-314b-a3f6">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition type="atLeast" value="10" field="selections" scope="a037-a89c-f59f-8b1e" childId="model" shared="true" includeChildSelections="true"/>
-                      </conditions>
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition type="lessThan" value="1" field="selections" scope="a037-a89c-f59f-8b1e" childId="6215-3f01-f844-585" shared="true" includeChildSelections="true"/>
-                            <condition type="atLeast" value="1" field="selections" scope="a037-a89c-f59f-8b1e" childId="33b5-e668-d503-7039" shared="true" includeChildSelections="true"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-                <modifier type="set" value="0" field="702-d447-314b-a3f6">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition type="lessThan" value="10" field="selections" scope="a037-a89c-f59f-8b1e" childId="model" shared="true" includeChildSelections="true"/>
-                      </conditions>
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition type="greaterThan" value="0" field="selections" scope="a037-a89c-f59f-8b1e" childId="6215-3f01-f844-585" shared="true" includeChildSelections="true"/>
-                            <condition type="lessThan" value="1" field="selections" scope="a037-a89c-f59f-8b1e" childId="33b5-e668-d503-7039" shared="true" includeChildSelections="true"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="6a31-ca3-754e-60eb" collective="true">
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
-                  </constraints>
-                  <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="87e0-c162-6c8-5069">
-                      <characteristics>
-                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
-                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
-                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="79ff-1e23-827a-6361" targetId="e9c4-2bb8-12ee-cd1b"/>
-                  </infoLinks>
-                </selectionEntry>
-              </selectionEntries>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="4" field="selections" scope="parent" shared="true" id="e99f-6e07-1a6b-a4a4"/>
-            <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="e3fa-db46-4723-6423"/>
-          </constraints>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <categoryLinks>
+        <categoryLink id="9d95-2e93-1685-c8c6" name="Battleline" hidden="false" targetId="e338-111e-d0c6-b687" primary="true"/>
+        <categoryLink id="86f5-5745-852-cee" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="false"/>
+        <categoryLink id="b1a3-eea3-495b-20de" name="Grenades" hidden="false" targetId="5a61-81ac-eb7c-a87e" primary="false"/>
+        <categoryLink id="ff6d-4e99-9d83-68eb" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="744b-b162-910-70dd" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="927f-353a-80f5-4433" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="311f-74cb-9fa6-f53c" name="Terminator" hidden="false" targetId="740a-892c-8958-defa" primary="false"/>
+        <categoryLink id="7277-5b39-d794-7af5" name="Brotherhood Terminator Squad" hidden="false" targetId="cddf-ac1-4a0d-8e48" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Justicar" hidden="false" id="9151-d4f-9296-22cd">
+        <selectionEntry id="9151-d4f-9296-22cd" name="Justicar" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a751-8d41-7d7-b91f"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5558-5770-991c-1576"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a751-8d41-7d7-b91f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5558-5770-991c-1576" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="399-18e8-7d1f-41f8">
+            <selectionEntry id="399-18e8-7d1f-41f8" name="Nemesis Force Weapon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f1bb-cdb1-740a-d6e7"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="65e4-681d-9379-6b38"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1bb-cdb1-740a-d6e7" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65e4-681d-9379-6b38" type="max"/>
               </constraints>
               <profiles>
-                <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="cd0f-31f6-ae1-78b5">
+                <profile id="cd0f-31f6-ae1-78b5" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
                   <characteristics>
                     <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                     <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
@@ -1171,12 +1038,19 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink name="Psychic" hidden="false" type="rule" id="b5f8-bdf5-e25b-8737" targetId="e9c4-2bb8-12ee-cd1b"/>
+                <infoLink id="b5f8-bdf5-e25b-8737" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="68f7-b139-5b4d-b7ce">
+            <selectionEntry id="68f7-b139-5b4d-b7ce" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb0-a066-fff6-6b17" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae32-a00-4ac9-af33" type="max"/>
+              </constraints>
               <profiles>
-                <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="af49-1f7a-c394-20f5">
+                <profile id="af49-1f7a-c394-20f5" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                   <characteristics>
                     <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                     <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -1189,36 +1063,307 @@
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink name="Rapid Fire" hidden="false" type="rule" id="91b5-fdda-f17e-a67f" targetId="c5c8-8b58-b8b6-7786">
+                <infoLink id="91b5-fdda-f17e-a67f" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
                   <modifiers>
-                    <modifier type="append" value="2" field="name"/>
+                    <modifier type="append" field="name" value="2"/>
                   </modifiers>
                 </infoLink>
               </infoLinks>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="fb0-a066-fff6-6b17"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ae32-a00-4ac9-af33"/>
-              </constraints>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Castellan Crowe" hidden="false" id="9ddb-760d-8cf7-1c8a">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2da-fe4-d745-7dda" name="Terminators (4-9)" hidden="false" collective="false" import="false" defaultSelectionEntryId="f5c5-56fd-51ec-d1a6">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e99f-6e07-1a6b-a4a4" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3fa-db46-4723-6423" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f5c5-56fd-51ec-d1a6" name="Terminator" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca99-81d5-43f8-de75" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="261c-9752-7bd3-7bf2" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="1205-b96b-bcfc-40c3" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                      <characteristics>
+                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
+                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
+                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
+                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
+                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="fa00-da2b-3beb-431e" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="aa86-238b-9ca6-7504" name="Storm Bolter" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77a-f8d6-ae23-1a1d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="7b12-a858-6de3-4ee2" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                      <characteristics>
+                        <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                        <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                        <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                        <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                        <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="8a35-6814-4656-9c79" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
+                      <modifiers>
+                        <modifier type="append" field="name" value="2"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6215-3f01-f844-585" name="Terminator with Ancient&apos;s Banner" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26c3-5023-9a33-4c8" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="3934-1e64-5a6a-8e54" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="85b5-9fcc-d929-8477" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                      <characteristics>
+                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
+                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
+                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
+                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
+                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="73b9-bf-a242-b68c" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="55ab-530-9b32-a5d0" name="Ancient&apos;s Banner" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ced-59bb-1646-d784" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1060-a780-b862-b87b" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="1e79-d50f-92b3-4ce4" name="Ancient&apos;s Banner" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+                      <characteristics>
+                        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Add 1 to the Objective Control characteristic of models in the bearer’s unit.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="c9a0-cf4e-fb96-6bf1" name="Weapon Choice" hidden="false" collective="false" import="false" defaultSelectionEntryId="33b5-e668-d503-7039">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaaa-819b-640a-c8a5" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10ad-89fc-41f8-a5eb" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="33b5-e668-d503-7039" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+                      <profiles>
+                        <profile id="7bb3-feb-8824-b24" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                          <characteristics>
+                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                            <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                            <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <infoLinks>
+                        <infoLink id="2977-f794-39a0-c594" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
+                          <modifiers>
+                            <modifier type="append" field="name" value="2"/>
+                          </modifiers>
+                        </infoLink>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="22fd-3d1b-9957-2d5f" name="Terminator with Narthecium" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73f3-7268-a1f4-ccb0" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="29dd-35d3-910f-c1c4" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="7ec2-c49e-ba02-c802" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                      <characteristics>
+                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
+                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
+                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
+                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
+                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="e99d-16e3-a591-c0e1" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="65d9-e2ef-776d-f579" name="Narthecium" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c970-d110-2a59-afb1" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab3b-201b-e05e-1c22" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="97ca-b4cb-c700-e6c2" name="Narthecium" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+                      <characteristics>
+                        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">In your Command phase, you can return 1 destroyed model (excluding Characters) to the bearer’s unit</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="77d3-d321-bb86-dabe" name="Terminator with Heavy Weapon" hidden="false" collective="false" import="true" type="model">
+              <modifiers>
+                <modifier type="set" field="702-d447-314b-a3f6" value="2">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="a037-a89c-f59f-8b1e" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="a037-a89c-f59f-8b1e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6215-3f01-f844-585" type="lessThan"/>
+                            <condition field="selections" scope="a037-a89c-f59f-8b1e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33b5-e668-d503-7039" type="atLeast"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="702-d447-314b-a3f6" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="6a31-ca3-754e-60eb" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="87e0-c162-6c8-5069" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                      <characteristics>
+                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
+                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
+                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
+                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
+                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="79ff-1e23-827a-6361" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="c1b7-ce3c-faf0-2090" name="Heavy Weapon" hidden="false" collective="false" import="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91fc-5d4d-70a1-955f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b66e-ec0f-231-9d5f" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="414-6fc2-8423-f86e" name="Incinerator" hidden="false" collective="false" import="true" targetId="17ed-2f7b-bf3a-3c94" type="selectionEntry"/>
+                    <entryLink id="3ccf-db10-dc87-3038" name="Psilencer" hidden="false" collective="false" import="true" targetId="d526-d040-807c-34f6" type="selectionEntry"/>
+                    <entryLink id="39bd-f647-4b4d-9494" name="Psycannon" hidden="false" collective="false" import="true" targetId="e520-9c7-d10c-897d" type="selectionEntry"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="75"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="210.0"/>
       </costs>
-      <categoryLinks>
-        <categoryLink targetId="de95-1b68-44cf-7ca9" id="3415-125a-dd0e-b039" primary="false" name="Castellan Crowe"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="e664-deab-e778-323" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="a383-b0fe-5c5c-4236" primary="false" name="Psyker"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="a184-f5d4-957c-b8a6" primary="false" name="Imperium"/>
-        <categoryLink targetId="4f3a-f0f7-6647-348d" id="8cfc-c1ef-5722-d8e6" primary="true" name="Epic Hero"/>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="94f-cf05-f0db-2b64" primary="false" name="Infantry"/>
-        <categoryLink targetId="9cfd-1c32-585f-7d5c" id="53c2-253c-4f3-df1c" primary="false" name="Character"/>
-      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry id="9ddb-760d-8cf7-1c8a" name="Castellan Crowe" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile name="Castellan Crowe" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="7aa4-66e9-1046-f76e">
+        <profile id="7aa4-66e9-1046-f76e" name="Castellan Crowe" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">6&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">4</characteristic>
@@ -1228,17 +1373,17 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
           </characteristics>
         </profile>
-        <profile name="Champion of the Order of Purifiers (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="3cd-1880-37fe-4cfc">
+        <profile id="3cd-1880-37fe-4cfc" name="Champion of the Order of Purifiers (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, add 1 to the Attacks characteristic of that unit’s Purifying Flame.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Foresight of the Prognosticars (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="7414-1762-a008-9828">
+        <profile id="7414-1762-a008-9828" name="Foresight of the Prognosticars (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Once per turn, the first time a saving throw is failed for this model, change the Damage characteristic of that attack to 0</characteristic>
           </characteristics>
         </profile>
-        <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="722a-9e45-fe18-94aa">
+        <profile id="722a-9e45-fe18-94aa" name="Leader" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following unit:
 ■ Purifier Squad</characteristic>
@@ -1246,14 +1391,27 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="e09e-913c-8134-757b" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Leader" hidden="false" type="rule" id="d946-7c6-9030-b5d7" targetId="b4dd-3e1f-41cb-218f"/>
-        <infoLink name="Invulnerable Save (4+)" hidden="false" type="profile" id="3d0f-ed92-a950-b8f" targetId="df6-e949-835b-ad0d"/>
+        <infoLink id="e09e-913c-8134-757b" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="d946-7c6-9030-b5d7" name="Leader" hidden="false" targetId="b4dd-3e1f-41cb-218f" type="rule"/>
+        <infoLink id="3d0f-ed92-a950-b8f" name="Invulnerable Save (4+)" hidden="false" targetId="df6-e949-835b-ad0d" type="profile"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3415-125a-dd0e-b039" name="Castellan Crowe" hidden="false" targetId="de95-1b68-44cf-7ca9" primary="false"/>
+        <categoryLink id="e664-deab-e778-323" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="a383-b0fe-5c5c-4236" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="a184-f5d4-957c-b8a6" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="8cfc-c1ef-5722-d8e6" name="Epic Hero" hidden="false" targetId="4f3a-f0f7-6647-348d" primary="true"/>
+        <categoryLink id="94f-cf05-f0db-2b64" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="false"/>
+        <categoryLink id="53c2-253c-4f3-df1c" name="Character" hidden="false" targetId="9cfd-1c32-585f-7d5c" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Purifying Flame" hidden="false" id="ba75-d1eb-5347-28b3" collective="false">
+        <selectionEntry id="ba75-d1eb-5347-28b3" name="Purifying Flame" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a74-db6c-c1f9-6c02" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca48-7264-b8b4-4d77" type="max"/>
+          </constraints>
           <profiles>
-            <profile name="Purifying Flame" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="73f3-22f9-3831-441a">
+            <profile id="73f3-22f9-3831-441a" name="Purifying Flame" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
@@ -1266,18 +1424,21 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Ignores Cover" hidden="false" type="rule" id="6f01-b395-3fdb-d92" targetId="4640-43e7-30b-215a"/>
-            <infoLink name="Psychic" hidden="false" type="rule" id="f385-d8b1-a07-7cfb" targetId="e9c4-2bb8-12ee-cd1b"/>
-            <infoLink name="Anti-" hidden="false" type="rule" id="2dad-d6f2-2afb-6568" targetId="4111-82e3-9444-e942"/>
+            <infoLink id="6f01-b395-3fdb-d92" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+            <infoLink id="f385-d8b1-a07-7cfb" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+            <infoLink id="2dad-d6f2-2afb-6568" name="Anti-" hidden="false" targetId="4111-82e3-9444-e942" type="rule"/>
           </infoLinks>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2a74-db6c-c1f9-6c02"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ca48-7264-b8b4-4d77"/>
-          </constraints>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="9a7a-e845-e81f-6b87">
+        <selectionEntry id="9a7a-e845-e81f-6b87" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11a3-8954-73c5-f558" type="min"/>
+          </constraints>
           <profiles>
-            <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="c19e-b7d3-83b7-78fa">
+            <profile id="c19e-b7d3-83b7-78fa" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -1290,20 +1451,23 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Rapid Fire" hidden="false" type="rule" id="d901-f7ba-486f-c84f" targetId="c5c8-8b58-b8b6-7786">
+            <infoLink id="d901-f7ba-486f-c84f" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
               <modifiers>
-                <modifier type="append" value="2" field="name"/>
+                <modifier type="append" field="name" value="2"/>
               </modifiers>
             </infoLink>
           </infoLinks>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="11a3-8954-73c5-f558"/>
-          </constraints>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Black Blade of Antwyr" hidden="false" id="9bcc-8f6e-67ea-6c75">
+        <selectionEntry id="9bcc-8f6e-67ea-6c75" name="Black Blade of Antwyr" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f437-78b4-7e74-e327" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b51-6fef-1895-9323" type="max"/>
+          </constraints>
           <profiles>
-            <profile name="Black Blade of Antwyr" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="dae1-9183-96d9-6ccd">
+            <profile id="dae1-9183-96d9-6ccd" name="Black Blade of Antwyr" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                 <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
@@ -1315,36 +1479,25 @@
               </characteristics>
             </profile>
           </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f437-78b4-7e74-e327"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4b51-6fef-1895-9323"/>
-          </constraints>
           <infoLinks>
-            <infoLink name="Devastating Wounds" hidden="false" type="rule" id="211-3235-289-ad06" targetId="be1e-ac8e-1e2c-3528"/>
-            <infoLink name="Precision" hidden="false" type="rule" id="89a7-3b44-39c3-6eca" targetId="9143-31ae-e0a6-6007"/>
+            <infoLink id="211-3235-289-ad06" name="Devastating Wounds" hidden="false" targetId="be1e-ac8e-1e2c-3528" type="rule"/>
+            <infoLink id="89a7-3b44-39c3-6eca" name="Precision" hidden="false" targetId="9143-31ae-e0a6-6007" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="29ce-108e-9134-cf64" targetId="beae-4593-3686-1672"/>
+        <entryLink id="29ce-108e-9134-cf64" name="Warlord" hidden="false" collective="false" import="true" targetId="beae-4593-3686-1672" type="selectionEntry"/>
       </entryLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Grand Master" hidden="false" id="1a56-706b-a8f1-631a">
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="95"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="75.0"/>
       </costs>
-      <categoryLinks>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="7237-6cec-9820-c8f4" primary="false" name="Infantry"/>
-        <categoryLink targetId="9cfd-1c32-585f-7d5c" id="f74b-b785-12b1-5d1e" primary="true" name="Character"/>
-        <categoryLink targetId="5a61-81ac-eb7c-a87e" id="85fd-2b8b-431a-87d9" primary="false" name="Grenades"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="b751-b16b-a94-b96e" primary="false" name="Psyker"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="8fd8-1038-b765-2b00" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="740a-892c-8958-defa" id="83e2-e0a9-4646-22ce" primary="false" name="Terminator"/>
-        <categoryLink targetId="ce31-227c-65ca-e27e" id="f5c9-5b1e-2f0f-1e5c" primary="false" name="Grand Master"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="a2f9-d54f-3c51-73a" primary="false" name="Imperium"/>
-      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry id="1a56-706b-a8f1-631a" name="Grand Master" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile name="Grand Master" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="425b-899c-7e54-95a">
+        <profile id="425b-899c-7e54-95a" name="Grand Master" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">5&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">5</characteristic>
@@ -1354,17 +1507,17 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
           </characteristics>
         </profile>
-        <profile name="Might of Purity (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="f271-762e-61ae-367f">
+        <profile id="f271-762e-61ae-367f" name="Might of Purity (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, you can ignore any or all modifiers to the characteristics of models in that unit and to any roll or test made for models in that unit (excluding modifiers to saving throws).</characteristic>
           </characteristics>
         </profile>
-        <profile name="Master Strategist" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="cb03-8115-df85-19ac">
+        <profile id="cb03-8115-df85-19ac" name="Master Strategist" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Once per battle, one unit from your army with this ability can be targeted by a Stratagem for 0CP, even if another unit from your army has already been targeted by that Stratagem this phase.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="ecd8-2298-e581-30d1">
+        <profile id="ecd8-2298-e581-30d1" name="Leader" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
 ■ Brotherhood Terminator Squad
@@ -1373,112 +1526,27 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="14-5133-4c03-b851" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Invulnerable Save (4+)" hidden="false" type="profile" id="c3ec-3c2e-bfc9-8c11" targetId="df6-e949-835b-ad0d"/>
+        <infoLink id="14-5133-4c03-b851" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="c3ec-3c2e-bfc9-8c11" name="Invulnerable Save (4+)" hidden="false" targetId="df6-e949-835b-ad0d" type="profile"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Weapon Choice" hidden="false" id="1afc-d16b-2a31-bea8" defaultSelectionEntryId="903a-b2d-bf56-4652">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Psycannon" hidden="false" id="be75-9ce5-95d5-a03f">
-              <infoLinks>
-                <infoLink name="Psychic" hidden="false" type="rule" id="b0d7-125e-120b-c870" targetId="e9c4-2bb8-12ee-cd1b"/>
-              </infoLinks>
-              <profiles>
-                <profile name="Psycannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="6c01-bb6c-d302-2c5f">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Incinerator" hidden="false" id="aa13-af0a-18e-f507">
-              <profiles>
-                <profile name="Incinerator" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="ef25-68c6-3657-3631">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Torrent</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink name="Ignores Cover" hidden="false" type="rule" id="f696-eaae-af1e-f976" targetId="4640-43e7-30b-215a"/>
-                <infoLink name="Torrent" hidden="false" type="rule" id="f699-9f4a-7f97-69a" targetId="5edf-d619-23e0-9b56"/>
-              </infoLinks>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Psilencer" hidden="false" id="4d85-10bc-912c-c316">
-              <profiles>
-                <profile name="Psilencer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="a104-a22d-8852-5085">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic, Sustained Hits 1</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink name="Sustained Hits" hidden="false" type="rule" id="a292-2940-af73-8c7c" targetId="1897-c22c-9597-12b1">
-                  <modifiers>
-                    <modifier type="append" value="1" field="name"/>
-                  </modifiers>
-                </infoLink>
-                <infoLink name="Psychic" hidden="false" type="rule" id="7579-eaad-6016-e7fb" targetId="e9c4-2bb8-12ee-cd1b"/>
-              </infoLinks>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="903a-b2d-bf56-4652">
-              <profiles>
-                <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="9450-9bba-d8db-2391">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink name="Rapid Fire" hidden="false" type="rule" id="8516-8510-9ec5-bc73" targetId="c5c8-8b58-b8b6-7786">
-                  <modifiers>
-                    <modifier type="append" value="2" field="name"/>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-              </constraints>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="91fc-5d4d-70a1-955f"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b66e-ec0f-231-9d5f"/>
-          </constraints>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <categoryLinks>
+        <categoryLink id="7237-6cec-9820-c8f4" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="false"/>
+        <categoryLink id="f74b-b785-12b1-5d1e" name="Character" hidden="false" targetId="9cfd-1c32-585f-7d5c" primary="true"/>
+        <categoryLink id="85fd-2b8b-431a-87d9" name="Grenades" hidden="false" targetId="5a61-81ac-eb7c-a87e" primary="false"/>
+        <categoryLink id="b751-b16b-a94-b96e" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="8fd8-1038-b765-2b00" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="83e2-e0a9-4646-22ce" name="Terminator" hidden="false" targetId="740a-892c-8958-defa" primary="false"/>
+        <categoryLink id="f5c9-5b1e-2f0f-1e5c" name="Grand Master" hidden="false" targetId="ce31-227c-65ca-e27e" primary="false"/>
+        <categoryLink id="a2f9-d54f-3c51-73a" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="1cca-ad4-74e7-cd9e" collective="true">
+        <selectionEntry id="1cca-ad4-74e7-cd9e" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
           </constraints>
           <profiles>
-            <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="182b-3191-8fa-53e1">
+            <profile id="182b-3191-8fa-53e1" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                 <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
@@ -1491,160 +1559,47 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Psychic" hidden="false" type="rule" id="f21d-49a3-33fc-219a" targetId="e9c4-2bb8-12ee-cd1b"/>
+            <infoLink id="f21d-49a3-33fc-219a" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
-      <entryLinks>
-        <entryLink import="true" name="Teleport Strike Force" hidden="false" type="selectionEntryGroup" id="1a4e-5c6c-8439-14cb" targetId="c440-b056-f09a-c88a"/>
-        <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="c39a-5b6b-531e-dabb" targetId="beae-4593-3686-1672"/>
-      </entryLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Grand Master in Nemesis Dreadknight" hidden="false" id="3625-f9f1-122b-bf9d">
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="200"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="9cfd-1c32-585f-7d5c" id="3b60-8849-d491-a2d5" primary="true" name="Character"/>
-        <categoryLink targetId="dbd4-63-af05-998" id="d8d4-f8c1-b4ca-4c57" primary="false" name="Vehicle"/>
-        <categoryLink targetId="6dda-e157-334d-e93a" id="8a03-abaa-c69e-7abe" primary="false" name="Walker"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="85f4-acbe-d457-b127" primary="false" name="Psyker"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="1226-741e-a60d-10b4" primary="false" name="Imperium"/>
-        <categoryLink targetId="a738-1a96-db57-ba6f" id="2832-4a22-ce58-de18" primary="false" name="Grand Master in Nemesis Dreadknight"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Grand Master in Nemesis Dreadknight" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="cb71-5829-f1d5-e7da">
-          <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">8&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">8</characteristic>
-            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">13</characteristic>
-            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
-            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">4</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Surge of Wrath (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="1ee5-63a2-6c01-e628">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Once per battle round, in the Fight phase, one model from your army with this ability can use it before resolving its attacks. If it does, until the end of the phase, each time that model makes an attack that targets a Monster or Vehicle unit, you can re-roll the Hit roll, you can re-roll the Wound roll and you can re-roll the Damage roll.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Heroism’s Favour" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="dce-9e37-9f2-5687">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time you target this model with a Stratagem, it only costs 1CP to use, even if the CP cost is higher</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Damaged: 1-4 Wounds Remaining" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="abf6-e340-d8e8-5486">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-4 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="e21a-e2fc-96f0-af31" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Deadly Demise" hidden="false" type="rule" id="0p5g-a5y9-4n8o-8d3t" targetId="b68a-5ded-65ac-98c">
-          <modifiers>
-            <modifier type="append" value="D3" field="name"/>
-          </modifiers>
-        </infoLink>
-        <infoLink name="Invulnerable Save (4+)" hidden="false" type="profile" id="ae9f-6e8a-86ac-5830" targetId="df6-e949-835b-ad0d"/>
-      </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup name="Melee Weapon" hidden="false" id="2bd0-3b67-972f-a8f6" defaultSelectionEntryId="2eb9-3493-e588-49f4">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Dreadfists" hidden="false" id="2eb9-3493-e588-49f4">
-              <profiles>
-                <profile name="Dreadfists" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="5d7f-39d-623-d7e4">
-                  <characteristics>
-                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                    <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
-                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-1</characteristic>
-                    <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
-                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Nemesis Greatsword" hidden="false" id="52c4-b7dd-788f-264b">
-              <profiles>
-                <profile name="➤ Nemesis Greatsword - Strike" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="9704-7c3f-854b-9e25">
-                  <characteristics>
-                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
-                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">10</characteristic>
-                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                    <characteristic name="D" typeId="3254-9fe6-d824-513e">D6</characteristic>
-                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="➤ Nemesis Greatsword - Sweep" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="42ff-de93-e506-163b">
-                  <characteristics>
-                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                    <characteristic name="A" typeId="2337-daa1-6682-b110">10</characteristic>
-                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">5</characteristic>
-                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-1</characteristic>
-                    <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
-                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Nemesis Daemon Greathammer" hidden="false" id="3b80-a160-3eec-4e00">
-              <profiles>
-                <profile name="Nemesis Daemon Greathammer" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="a32f-5090-8226-9c17">
-                  <characteristics>
-                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
-                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
-                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">14</characteristic>
-                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-3</characteristic>
-                    <characteristic name="D" typeId="3254-9fe6-d824-513e">D6+1</characteristic>
-                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
+        <selectionEntryGroup id="1afc-d16b-2a31-bea8" name="Weapon Choice" hidden="false" collective="false" import="false" defaultSelectionEntryId="903a-b2d-bf56-4652">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8a82-2089-499b-22f5"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5a52-d62d-bc42-4638"/>
-          </constraints>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Ranged Weapons" hidden="false" id="5a6-d46b-4cbb-bb52">
-          <constraints>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="fc9b-65d8-6819-f049"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91fc-5d4d-70a1-955f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b66e-ec0f-231-9d5f" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Gatling Psilencer" hidden="false" id="deb-48a9-1858-abdc">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="726a-32bc-86bf-3e4d"/>
-              </constraints>
+            <selectionEntry id="be75-9ce5-95d5-a03f" name="Psycannon" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
-                <profile name="Gatling Psilencer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="5e8d-f93d-3256-6e7d">
+                <profile id="6c01-bb6c-d302-2c5f" name="Psycannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                   <characteristics>
                     <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">12</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic, Sustained Hits 1</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
+              <infoLinks>
+                <infoLink id="b0d7-125e-120b-c870" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Heavy Incinerator" hidden="false" id="8f86-8d31-fcf8-ea68">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="abc4-70df-6525-ab6a"/>
-              </constraints>
+            <selectionEntry id="aa13-af0a-18e-f507" name="Incinerator" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
-                <profile name="Heavy Incinerator" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="c0e-1834-7ad8-d882">
+                <profile id="ef25-68c6-3657-3631" name="Incinerator" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                   <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2D6</characteristic>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
                     <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
                     <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
                     <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
@@ -1653,1628 +1608,46 @@
                   </characteristics>
                 </profile>
               </profiles>
+              <infoLinks>
+                <infoLink id="f696-eaae-af1e-f976" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+                <infoLink id="f699-9f4a-7f97-69a" name="Torrent" hidden="false" targetId="5edf-d619-23e0-9b56" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Heavy Psycannon" hidden="false" id="b20b-53f6-d6da-c537">
+            <selectionEntry id="4d85-10bc-912c-c316" name="Psilencer" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="a104-a22d-8852-5085" name="Psilencer" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic, Sustained Hits 1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="a292-2940-af73-8c7c" name="Sustained Hits" hidden="false" targetId="1897-c22c-9597-12b1" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value="1"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="7579-eaad-6016-e7fb" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="903a-b2d-bf56-4652" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4d66-7435-917a-74fd"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
               </constraints>
               <profiles>
-                <profile name="Heavy Psycannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="25fb-aa58-5f17-686b">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">10</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">3</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink import="true" name="Teleport Strike Force" hidden="false" type="selectionEntryGroup" id="13f3-6d13-7623-8dec" targetId="c440-b056-f09a-c88a"/>
-        <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="9bc3-1965-bdc8-2169" targetId="beae-4593-3686-1672"/>
-      </entryLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Grand Master Voldus" hidden="false" id="7256-bb3a-3e79-31fe">
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="95"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="4f3a-f0f7-6647-348d" id="aabc-29c2-3bc5-2888" primary="true" name="Epic Hero"/>
-        <categoryLink targetId="9cfd-1c32-585f-7d5c" id="dddb-e1e6-d696-9d6" primary="false" name="Character"/>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="2c13-72b8-f7b5-a66" primary="false" name="Infantry"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="6ba-ee10-2110-513b" primary="false" name="Psyker"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="967c-a830-562a-a78c" primary="false" name="Imperium"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="57aa-503b-4257-a5c5" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="740a-892c-8958-defa" id="70aa-d5d4-4005-cdc2" primary="false" name="Terminator"/>
-        <categoryLink targetId="472c-f807-880-b6" id="54be-fb0d-c179-66b0" primary="false" name="Grand Master Voldus"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Grand Master Voldus" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="a37-8a28-de0e-8df5">
-          <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">5&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">5</characteristic>
-            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">6</characteristic>
-            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
-            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Sanctuary (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="b513-f80c-9d48-db05">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, each time an attack targets that unit, subtract 1 from the Hit roll.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Hammer Aflame (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="bf8c-be10-e632-646d">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model’s unit is selected to fight, you can select one enemy unit within Engagement Range of this model’s unit and roll one D6, adding 2 to the result if that unit has the Daemon keyword: on a 4-5, that enemy unit suffers D3 mortal wounds; on a 6+, that enemy unit suffers D3+3 mortal wounds.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="3de3-b31e-7c05-aba8">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
-■ Brotherhood Terminator Squad
-■ Paladin Squad</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="4369-e175-5ac5-231b" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Leader" hidden="false" type="rule" id="5034-3b66-4628-9ee0" targetId="b4dd-3e1f-41cb-218f"/>
-        <infoLink name="Invulnerable Save (4+)" hidden="false" type="profile" id="8636-b62a-9ee4-842a" targetId="df6-e949-835b-ad0d"/>
-      </infoLinks>
-      <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="90bf-576e-e6e1-34f3">
-          <profiles>
-            <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="f8f5-d926-d76f-9404">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink name="Rapid Fire" hidden="false" type="rule" id="6ac7-e98f-acea-61aa" targetId="c5c8-8b58-b8b6-7786">
-              <modifiers>
-                <modifier type="append" value="2" field="name"/>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="11a3-8954-73c5-f558"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Malleus Argyrum" hidden="false" id="6b5f-a7fc-2a1b-b24e">
-          <profiles>
-            <profile name="Malleus Argyrum" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="9c20-33ed-5139-f2df">
-              <characteristics>
-                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
-                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">2+</characteristic>
-                <characteristic name="S" typeId="ab33-d393-96ce-ccba">10</characteristic>
-                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                <characteristic name="D" typeId="3254-9fe6-d824-513e">3</characteristic>
-                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="74bd-1b90-ed9e-d18e"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="fc94-131a-657e-9206"/>
-          </constraints>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="b226-1312-fee6-ae5e" targetId="beae-4593-3686-1672"/>
-      </entryLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Grey Knights Land Raider" hidden="false" id="512d-b972-911e-4cac">
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="240"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="dbd4-63-af05-998" id="22e9-f614-a41f-1ec9" primary="true" name="Vehicle"/>
-        <categoryLink targetId="6df-937-16bc-8c1a" id="48d8-c3b9-26d8-5dd" primary="false" name="Smoke"/>
-        <categoryLink targetId="75e8-57c4-40e3-1817" id="a6c7-5a01-5363-49b2" primary="false" name="Transport"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="2747-434a-c047-c33a" primary="false" name="Imperium"/>
-        <categoryLink targetId="adfb-534b-3eb7-2781" id="f13d-271c-abfb-fa0" primary="false" name="Grey Knights Land Raider"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Grey Knights Land Raider" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="5eb5-ef56-7823-faa0">
-          <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">10&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">12</characteristic>
-            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">16</characteristic>
-            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
-            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">5</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Assault Ramp" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="c1d5-950b-12b6-7201">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a unit disembarks from this model after it has made a Normal move, that unit is still eligible to declare a charge this turn.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Damaged: 1-5 Wounds Remaining" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="e6a-44ad-c190-51c5">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-5 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Grey Knights Land Raider" typeId="74f8-5443-9d6d-1f1e" typeName="Transport" hidden="false" id="511a-e5a0-5e4f-89e4">
-          <characteristics>
-            <characteristic name="Capacity" typeId="30f2-be70-861d-1b84">This model has a transport capacity of 12 Grey Knights Infantry models. Each Terminator model takes up the space of 2 models</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Godhammer Lascannon" hidden="false" id="ff0-5d7d-c73b-9c5f">
-          <profiles>
-            <profile name="Godhammer Lascannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="da8a-8a15-3669-95d0">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">12</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="b554-1c9a-2d88-57d1"/>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="2d7c-bd88-37b9-1210"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Hunter-killer Missile" hidden="false" id="b9c1-621d-4e2c-ec53">
-          <profiles>
-            <profile name="Hunter-killer Missile" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="9d99-67d2-33bb-e550">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">14</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">One Shot</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c6d5-9a69-e0a6-bd98"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="45b2-6705-e24e-4378">
-          <profiles>
-            <profile name="Multi-melta" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="9a39-e37c-3cda-db11">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Melta 2</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4f07-a7a3-8139-1a13"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Twin Heavy Bolter" hidden="false" id="a267-d6e8-d2f9-e9e5">
-          <profiles>
-            <profile name="Twin Heavy Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="559a-2e12-8e8c-53af">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Sustained Hits 1, Twin-Linked</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="29ec-e7e8-f0dc-dec7"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6775-ae10-22c-bae5"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="a3fa-1259-f3cb-f873">
-          <profiles>
-            <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="fdf5-68b9-b99e-beb9">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink name="Rapid Fire" hidden="false" type="rule" id="ae9a-7702-d08d-f8f8" targetId="c5c8-8b58-b8b6-7786">
-              <modifiers>
-                <modifier type="append" value="2" field="name"/>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Armoured tracks" hidden="false" id="cfd1-5e6a-36c3-7997">
-          <profiles>
-            <profile name="Armoured tracks" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="c515-8bde-e0ab-5c4e">
-              <characteristics>
-                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
-                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
-                <characteristic name="S" typeId="ab33-d393-96ce-ccba">8</characteristic>
-                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
-                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
-                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8faa-a315-f9a7-1b5f"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f4d-2704-48ab-2eba"/>
-          </constraints>
-        </selectionEntry>
-      </selectionEntries>
-      <infoLinks>
-        <infoLink name="Deadly Demise" hidden="false" type="rule" id="z5h8-a351-4t8o-p1c4" targetId="b68a-5ded-65ac-98c">
-          <modifiers>
-            <modifier type="append" value="D6" field="name"/>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Grey Knights Land Raider Crusader" hidden="false" id="4c63-cca-8d26-6330">
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="230"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="dbd4-63-af05-998" id="6883-f1e6-130c-1042" primary="true" name="Vehicle"/>
-        <categoryLink targetId="75e8-57c4-40e3-1817" id="e0fc-d4c8-8e98-510d" primary="false" name="Transport"/>
-        <categoryLink targetId="6df-937-16bc-8c1a" id="ba68-5ea0-4f9e-2dd4" primary="false" name="Smoke"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="112d-a130-24a8-1ac4" primary="false" name="Imperium"/>
-        <categoryLink targetId="5a61-81ac-eb7c-a87e" id="cee7-cbe9-4b88-6fe4" primary="false" name="Grenades"/>
-        <categoryLink targetId="4a04-1f1b-8ffb-b183" id="fd99-568c-8e1-3c50" primary="false" name="Grey Knights Land Raider Crusader"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Grey Knights Land Raider Crusader" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="88aa-3a4d-4ff3-1b4c">
-          <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">12&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">12</characteristic>
-            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">16</characteristic>
-            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
-            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">5</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Assault Ramp" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="c059-84a-5bf2-dcbf">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a unit disembarks from this model after it has made a Normal move, that unit is still eligible to declare a charge this turn.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Damaged: 1-5 Wounds Remaining" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="cfb3-a59a-4eb1-1079">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-5 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Grey Knights Land Raider Crusader" typeId="74f8-5443-9d6d-1f1e" typeName="Transport" hidden="false" id="4c37-b59b-e445-d686">
-          <characteristics>
-            <characteristic name="Capacity" typeId="30f2-be70-861d-1b84">This model has a transport capacity of 16 Grey Knights Infantry models. Each Terminator model takes up the space of 2 models</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="3e8f-4409-e8e1-e0f6">
-          <profiles>
-            <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="a2c2-3246-5b1d-ec4">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink name="Rapid Fire" hidden="false" type="rule" id="dde4-1e5b-532e-c5ac" targetId="c5c8-8b58-b8b6-7786">
-              <modifiers>
-                <modifier type="append" value="2" field="name"/>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="9b02-db16-f3e1-2ba6">
-          <profiles>
-            <profile name="Multi-melta" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="fe87-8a70-818d-e92a">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Melta 2</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4f07-a7a3-8139-1a13"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Hunter-killer Missile" hidden="false" id="826e-a7e2-6487-697f">
-          <profiles>
-            <profile name="Hunter-killer Missile" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="a397-5107-56e3-186e">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">14</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">One Shot</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c6d5-9a69-e0a6-bd98"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Armoured tracks" hidden="false" id="d6c2-e486-b6f-dcf3">
-          <profiles>
-            <profile name="Armoured tracks" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="e8f7-2c18-6415-b114">
-              <characteristics>
-                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
-                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
-                <characteristic name="S" typeId="ab33-d393-96ce-ccba">8</characteristic>
-                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
-                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
-                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8faa-a315-f9a7-1b5f"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f4d-2704-48ab-2eba"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Hurricane Bolter" hidden="false" id="ed38-3e46-5c38-39d9">
-          <profiles>
-            <profile name="Hurricane Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="e382-718e-f1fa-aab7">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 6, Twin-Linked</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="3e83-5b45-e013-7181"/>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="e95e-dde9-eb95-6e6f"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Twin Assault Cannon" hidden="false" id="f061-6db7-ce1a-d3cb">
-          <profiles>
-            <profile name="Twin Assault Cannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="8057-da99-6365-6cc2">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Twin-Linked</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e1aa-547-7081-b185"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b4cd-e52d-9521-52d5"/>
-          </constraints>
-        </selectionEntry>
-      </selectionEntries>
-      <infoLinks>
-        <infoLink name="Deadly Demise" hidden="false" type="rule" id="z9y5-0m4z-1t7o-a160" targetId="b68a-5ded-65ac-98c">
-          <modifiers>
-            <modifier type="append" value="D6" field="name"/>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Grey Knights Land Raider Redeemer" hidden="false" id="ada7-eb0b-c920-d77f">
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="260"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="51dd-461e-1657-1017" id="f63-e411-a94b-b671" primary="false" name="Grey Knights Land Raider Redeemer"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="15a4-b6ff-d470-4278" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="5a61-81ac-eb7c-a87e" id="b9af-488c-f33c-ff4e" primary="false" name="Grenades"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="dbbe-40e3-b6f9-3f35" primary="false" name="Imperium"/>
-        <categoryLink targetId="dbd4-63-af05-998" id="67c0-7de9-2852-1d4c" primary="true" name="Vehicle"/>
-        <categoryLink targetId="75e8-57c4-40e3-1817" id="692c-54c1-472f-41d3" primary="false" name="Transport"/>
-        <categoryLink targetId="6df-937-16bc-8c1a" id="8e23-882d-4c2a-b3ec" primary="false" name="Smoke"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Grey Knights Land Raider Redeemer" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="36a8-d1b9-a5e8-b70f">
-          <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">12&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">12</characteristic>
-            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">16</characteristic>
-            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
-            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">5</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Grey Knights Land Raider Redeemer" typeId="74f8-5443-9d6d-1f1e" typeName="Transport" hidden="false" id="203b-c2a4-cba0-ee49">
-          <characteristics>
-            <characteristic name="Capacity" typeId="30f2-be70-861d-1b84">This model has a transport capacity of 14 Grey Knights Infantry models. Each Terminator model takes up the space of 2 models</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Assault Ramp" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="35e9-caef-a97f-a190">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a unit disembarks from this model after it has made a Normal move, that unit is still eligible to declare a charge this turn.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Damaged: 1-5 Wounds Remaining" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="df47-ae30-f628-3d25">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-5 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Twin Assault Cannon" hidden="false" id="7bf6-9fd5-5cd5-c1a6">
-          <profiles>
-            <profile name="Twin Assault Cannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="e8a9-8b39-81d8-a8a6">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Twin-Linked</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e1aa-547-7081-b185"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b4cd-e52d-9521-52d5"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="c05d-98a6-4648-fb81">
-          <profiles>
-            <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="ffd6-96d3-1e12-ec10">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink name="Rapid Fire" hidden="false" type="rule" id="1dcf-8a74-283c-1468" targetId="c5c8-8b58-b8b6-7786">
-              <modifiers>
-                <modifier type="append" value="2" field="name"/>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="8dd8-efec-de14-c678">
-          <profiles>
-            <profile name="Multi-melta" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="e882-abaf-59a2-bbaf">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Melta 2</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4f07-a7a3-8139-1a13"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Hunter-killer Missile" hidden="false" id="3917-9b44-e861-6f17">
-          <profiles>
-            <profile name="Hunter-killer Missile" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="9822-21fd-941-a5cf">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">14</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">One Shot</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c6d5-9a69-e0a6-bd98"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Armoured tracks" hidden="false" id="8ae2-ca88-19cf-2378">
-          <profiles>
-            <profile name="Armoured tracks" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="285d-4150-192f-12a4">
-              <characteristics>
-                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
-                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
-                <characteristic name="S" typeId="ab33-d393-96ce-ccba">8</characteristic>
-                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
-                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
-                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8faa-a315-f9a7-1b5f"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f4d-2704-48ab-2eba"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Flamestorm Cannon" hidden="false" id="47d2-bdb6-a769-cd0f">
-          <profiles>
-            <profile name="Flamestorm Cannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="f1a0-8910-1680-5177">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6+3</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Torrent</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="3c50-83ba-b6b2-e133"/>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="a255-68a7-2872-34a"/>
-          </constraints>
-        </selectionEntry>
-      </selectionEntries>
-      <infoLinks>
-        <infoLink name="Deadly Demise" hidden="false" type="rule" id="6n9a-b5m0-z02g-7hrb" targetId="b68a-5ded-65ac-98c">
-          <modifiers>
-            <modifier type="append" value="D6" field="name"/>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Grey Knights Razorback" hidden="false" id="841f-98b-fbf3-c8ee">
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="85"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="88ad-5f29-ba09-9427" id="1f3-5245-3cc2-e6cf" primary="false" name="Grey Knights Razorback"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="d083-4c1a-236a-7dfd" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="ba07-411c-2832-1f79" id="a381-cb06-2fe0-9834" primary="true" name="Dedicated Transport"/>
-        <categoryLink targetId="dbd4-63-af05-998" id="5f4e-96f1-fa70-7e18" primary="false" name="Vehicle"/>
-        <categoryLink targetId="75e8-57c4-40e3-1817" id="4b6e-cc44-6aa1-9863" primary="false" name="Transport"/>
-        <categoryLink targetId="6df-937-16bc-8c1a" id="90a2-3fed-cf2b-be5a" primary="false" name="Smoke"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="f70b-577c-5b88-829a" primary="false" name="Imperium"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Grey Knights Razorback" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="44b5-6d17-8379-c609">
-          <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">12&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">9</characteristic>
-            <characteristic name="SV" typeId="450-a17e-9d5e-29da">3+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">10</characteristic>
-            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
-            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">2</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Grey Knights Razorback" typeId="74f8-5443-9d6d-1f1e" typeName="Transport" hidden="false" id="69f9-2b19-561e-aeb5">
-          <characteristics>
-            <characteristic name="Capacity" typeId="30f2-be70-861d-1b84">This model has a transport capacity of 6 Grey Knights Infantry models. It cannot transport Terminator models.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Fire Support" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="b9fd-80d9-a165-1812">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">In your Shooting phase, after this model has shot, select one enemy unit it scored one or more hits against this phase. Until the end of the phase, each time a friendly model that disembarked from this Transport this turn makes an attack that targets that enemy unit, you can re-roll the Wound roll</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Armoured tracks" hidden="false" id="c22-6c03-9fcc-6a56">
-          <profiles>
-            <profile name="Armoured tracks" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="5cf3-d55c-1b15-a423">
-              <characteristics>
-                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
-                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
-                <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
-                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
-                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8faa-a315-f9a7-1b5f"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f4d-2704-48ab-2eba"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Hunter-killer Missile" hidden="false" id="e66a-945e-272a-74a2">
-          <profiles>
-            <profile name="Hunter-killer Missile" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="5b78-4de-2a6a-9a68">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">14</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">One Shot</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c6d5-9a69-e0a6-bd98"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="27b9-1a3e-1c8f-4918">
-          <profiles>
-            <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="330d-3463-fa04-568">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink name="Rapid Fire" hidden="false" type="rule" id="72d9-301-a0d2-f02e" targetId="c5c8-8b58-b8b6-7786">
-              <modifiers>
-                <modifier type="append" value="2" field="name"/>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-          </constraints>
-        </selectionEntry>
-      </selectionEntries>
-      <infoLinks>
-        <infoLink name="Deadly Demise" hidden="false" type="rule" id="p276-0a8z-1m59-m5x8" targetId="b68a-5ded-65ac-98c">
-          <modifiers>
-            <modifier type="append" value="D3" field="name"/>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Weapon Option" hidden="false" id="2831-c0e-a552-952a" defaultSelectionEntryId="4a1e-bc03-a5be-21c3">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Twin Heavy Bolter" hidden="false" id="4a1e-bc03-a5be-21c3">
-              <profiles>
-                <profile name="Twin Heavy Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="f5fc-169-bfb2-6bd8">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Sustained Hits 1, Twin-Linked</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Twin Assault Cannon" hidden="false" id="d90b-ac39-5ce5-4687">
-              <profiles>
-                <profile name="Twin Assault Cannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="84e9-ed79-ed6c-e524">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Twin-Linked</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Twin lascannon" hidden="false" id="c756-4d3d-897-c0b0">
-              <profiles>
-                <profile name="Twin lascannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="4053-cc1c-69a5-911f">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">12</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Twin-Linked</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="379c-a140-c939-189"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a9a-6186-7f85-d09"/>
-          </constraints>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Grey Knights Rhino" hidden="false" id="5ffd-f698-a1bb-fba7">
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="75"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="5ced-f445-91c2-a55e" id="bcf8-779b-c8c8-53b6" primary="false" name="Grey Knights Rhino"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="efb5-d648-92d5-5651" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="75e8-57c4-40e3-1817" id="c3d-3af1-1364-be04" primary="false" name="Transport"/>
-        <categoryLink targetId="dbd4-63-af05-998" id="94cf-eb82-d99-396d" primary="false" name="Vehicle"/>
-        <categoryLink targetId="ba07-411c-2832-1f79" id="1cf4-f88-9548-981e" primary="true" name="Dedicated Transport"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="6a2-5785-3e72-cb14" primary="false" name="Imperium"/>
-        <categoryLink targetId="6df-937-16bc-8c1a" id="d93f-65ef-ae59-b374" primary="false" name="Smoke"/>
-        <categoryLink targetId="50a2-5557-84bb-ca4d" id="91fd-28ef-15c1-31b" primary="false" name="Rhino"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Grey Knights Rhino" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="ceee-2a3f-1c1-3151">
-          <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">12&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">9</characteristic>
-            <characteristic name="SV" typeId="450-a17e-9d5e-29da">3+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">10</characteristic>
-            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
-            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">2</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Grey Knights Rhino" typeId="74f8-5443-9d6d-1f1e" typeName="Transport" hidden="false" id="4b87-568-feeb-bc57">
-          <characteristics>
-            <characteristic name="Capacity" typeId="30f2-be70-861d-1b84">This model has a transport capacity of 12 Grey Knights Infantry models. It cannot transport Terminator models.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Self Repair" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="3355-18b8-ee22-87f9">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">At the start of your Command phase, this model regains 1 lost wound.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Armoured tracks" hidden="false" id="e994-7f6f-3786-b476">
-          <profiles>
-            <profile name="Armoured tracks" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="c5e0-c829-98a5-880a">
-              <characteristics>
-                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
-                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
-                <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
-                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
-                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8faa-a315-f9a7-1b5f"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f4d-2704-48ab-2eba"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="37c7-1fb-eb45-8c5b">
-          <profiles>
-            <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="5349-e445-419-cb09">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink name="Rapid Fire" hidden="false" type="rule" id="fc29-1eca-e71c-d93" targetId="c5c8-8b58-b8b6-7786">
-              <modifiers>
-                <modifier type="append" value="2" field="name"/>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <constraints>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1d1e-fdff-c246-9bc4"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Hunter-killer Missile" hidden="false" id="9ee6-9eda-cd98-cd4a">
-          <profiles>
-            <profile name="Hunter-killer Missile" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="d74a-b284-964a-c781">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">14</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">One Shot</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c6d5-9a69-e0a6-bd98"/>
-          </constraints>
-        </selectionEntry>
-      </selectionEntries>
-      <infoLinks>
-        <infoLink name="Deadly Demise" hidden="false" type="rule" id="6m2i-0z8d-ci38-mt39" targetId="b68a-5ded-65ac-98c">
-          <modifiers>
-            <modifier type="append" value="D3" field="name"/>
-          </modifiers>
-        </infoLink>
-        <infoLink name="Firing Deck" hidden="false" type="rule" id="ca5a-1654-b3a5-f753" targetId="13b2-6518-dab3-7ea1">
-          <modifiers>
-            <modifier type="append" value="2" field="name"/>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Grey Knights Stormhawk Interceptor" hidden="false" id="fa-e288-2107-d22e">
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="160"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="82f-4771-c58e-1755" id="9d7c-5600-b20-bd83" primary="false" name="Grey Knights Stormhawk Interceptor"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="574b-ca51-2b5d-5dfc" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="dbd4-63-af05-998" id="b5fa-157c-ca4c-d806" primary="true" name="Vehicle"/>
-        <categoryLink targetId="63f1-e6e8-f6f6-a4f0" id="94c9-f0c7-afb7-8ddb" primary="false" name="Aircraft"/>
-        <categoryLink targetId="c619-2086-bbcf-69c9" id="b0e4-9547-be15-58ae" primary="false" name="Fly"/>
-        <categoryLink targetId="6df-937-16bc-8c1a" id="6165-3410-7c8b-6167" primary="false" name="Smoke"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="22cf-6b26-3e8d-3c98" primary="false" name="Imperium"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Grey Knights Stormhawk Interceptor" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="6013-ab9b-5543-f992">
-          <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">20+&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">9</characteristic>
-            <characteristic name="SV" typeId="450-a17e-9d5e-29da">3+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">10</characteristic>
-            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
-            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">0</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Interceptor" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="f531-b188-9179-2f5a">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model makes a ranged attack that targets a unit that can Fly, add 1 to the Hit roll</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Nose Gun" hidden="false" id="bd6d-2b6c-4d2d-ccfb" defaultSelectionEntryId="8d15-f7a6-1804-ae58">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Las-Talon" hidden="false" id="8d15-f7a6-1804-ae58">
-              <profiles>
-                <profile name="Las-Talon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="fb9-de3-ed8-a4f9">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">10</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Icarus Stormcannon" hidden="false" id="d9eb-e3b3-8a2-adba">
-              <profiles>
-                <profile name="Icarus Stormcannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="6530-32e9-6176-f896">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">7</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Anti-Fly 2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="351e-fe18-2863-997b"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2911-8e75-71a5-1a9d"/>
-          </constraints>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Side mounts" hidden="false" id="3768-739c-af00-fde4" defaultSelectionEntryId="5a7a-d41b-24c9-51f1">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7168-76a5-966b-f55e"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7bf8-16ed-1441-a82f"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Skyhammer Missile Launcher" hidden="false" id="5a7a-d41b-24c9-51f1">
-              <profiles>
-                <profile name="Skyhammer Missile Launcher" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="c43a-1763-f25b-ec54">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D3</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Anti-Fly 2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Typhoon Missile Launcher" hidden="false" id="ff7c-b295-5e15-57c">
-              <profiles>
-                <profile name="➤ Typhoon Missile launcher - Frag" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="2da1-5c5b-2397-87d8">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2D6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="➤ Typhoon Missile launcher - Krak" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="e20e-50d1-b8a8-746b">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Twin Heavy Bolter" hidden="false" id="d93c-7e31-c682-ea2e">
-              <profiles>
-                <profile name="Twin Heavy Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="3f09-8f41-984c-ef48">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Sustained Hits 1, Twin-Linked</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <infoLinks>
-        <infoLink name="Hover" hidden="false" type="rule" id="j5i1-0z0e-6713-8r5t" targetId="eec5-5f54-9c03-c305"/>
-        <infoLink name="Deadly Demise" hidden="false" type="rule" id="a9dk-t59s-c92e-zp4d" targetId="b68a-5ded-65ac-98c">
-          <modifiers>
-            <modifier type="append" value="D3" field="name"/>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-      <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Twin Assault Cannon" hidden="false" id="b040-e71a-dd4f-98f1">
-          <profiles>
-            <profile name="Twin Assault Cannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="a6cc-bd0d-a736-691e">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Twin-Linked</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e1aa-547-7081-b185"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b4cd-e52d-9521-52d5"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Armoured hull" hidden="false" id="527c-c236-4376-640b">
-          <profiles>
-            <profile name="Armoured hull" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="4c1a-4184-fbae-54f9">
-              <characteristics>
-                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
-                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
-                <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
-                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
-                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8faa-a315-f9a7-1b5f"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f4d-2704-48ab-2eba"/>
-          </constraints>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Grey Knights Stormraven Gunship" hidden="false" id="2efe-459b-9562-e7a9">
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="265"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="54b8-5bba-f749-e5ef" id="9dfe-1abf-8eb0-50f0" primary="false" name="Grey Knights Stormraven Gunship"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="511-5629-2d1f-367" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="63f1-e6e8-f6f6-a4f0" id="a5e5-37e-53e-34b5" primary="false" name="Aircraft"/>
-        <categoryLink targetId="dbd4-63-af05-998" id="ebc8-8b9a-701d-22f5" primary="true" name="Vehicle"/>
-        <categoryLink targetId="75e8-57c4-40e3-1817" id="45cf-409f-6bae-bb81" primary="false" name="Transport"/>
-        <categoryLink targetId="c619-2086-bbcf-69c9" id="489d-9fde-9665-edd1" primary="false" name="Fly"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="3bd9-2688-11f9-27ff" primary="false" name="Imperium"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Grey Knights Stormraven Gunship" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="f8c1-1eb7-cf09-7717">
-          <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">20+&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">10</characteristic>
-            <characteristic name="SV" typeId="450-a17e-9d5e-29da">3+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">14</characteristic>
-            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
-            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">0</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Armoured Resilience" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="c534-53bb-4d73-23d2">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time an attack is allocated to this model, subtract 1 from the Damage characteristic of that attack</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Damaged: 1-5 Wounds Remaining" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="5d24-6acb-2ed-b67">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-5 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Grey Knights Stormraven Gunship" typeId="74f8-5443-9d6d-1f1e" typeName="Transport" hidden="false" id="146c-72b7-bd76-e9ba">
-          <characteristics>
-            <characteristic name="Capacity" typeId="30f2-be70-861d-1b84">This model has a transport capacity of 12 Grey Knights Infantry models and 1 Grey Knights Venerable Dreadnought model. Each Terminator model takes up the space of 2 models</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Hurricane Bolter" hidden="false" id="aef0-cb77-f237-ca6a">
-          <profiles>
-            <profile name="Hurricane Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="452e-dfff-8d5d-ff0d">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 6, Twin-Linked</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="e95e-dde9-eb95-6e6f"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Stormstrike missile launcher" hidden="false" id="b2ea-93b8-8009-b652">
-          <profiles>
-            <profile name="Stormstrike missile launcher" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="6340-bb29-ab5e-a0c9">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">10</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+2</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="4ed2-d4f5-f24d-77c2"/>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="b82b-2ab0-a3-f771"/>
-          </constraints>
-        </selectionEntry>
-      </selectionEntries>
-      <infoLinks>
-        <infoLink name="Hover" hidden="false" type="rule" id="j5i1-126f-6802-m7i3" targetId="eec5-5f54-9c03-c305"/>
-        <infoLink name="Deadly Demise" hidden="false" type="rule" id="0b4l-bx92-m30d-0x4d" targetId="b68a-5ded-65ac-98c">
-          <modifiers>
-            <modifier type="append" value="D6" field="name"/>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Top Turret" hidden="false" id="67d-4c1b-48eb-1cfd" defaultSelectionEntryId="f1b9-fd0a-b087-2e4c">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Twin Assault Cannon" hidden="false" id="f1b9-fd0a-b087-2e4c">
-              <profiles>
-                <profile name="Twin Assault Cannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="6045-318b-104-ea21">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Twin-Linked</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Twin lascannon" hidden="false" id="716a-c91c-3254-d60c">
-              <profiles>
-                <profile name="Twin lascannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="3836-8269-1ad3-92dc">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">12</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Twin-Linked</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Twin Heavy plasma cannon" hidden="false" id="f72d-9efb-2c8e-e95c">
-              <profiles>
-                <profile name="➤ Twin Heavy plasma cannon - Standard" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="c6d3-899c-3edf-dd94">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">7</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast, Twin-Linked</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="➤ Twin Heavy plasma cannon - Supercharge" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="56b1-1619-dbc6-c1d">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">3</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast, Hazardous, Twin-Linked</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="48b1-7ad9-2a2e-325b"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3521-b91f-ec70-7c96"/>
-          </constraints>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Nose Mount" hidden="false" id="f56d-5657-3a1a-cfe7">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Twin Heavy Bolter" hidden="false" id="716a-979a-662c-5fae">
-              <profiles>
-                <profile name="Twin Heavy Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="6a9e-e5f7-870e-29bc">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Sustained Hits 1, Twin-Linked</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Typhoon Missile Launcher" hidden="false" id="843-6b91-5f47-c3e8">
-              <profiles>
-                <profile name="➤ Typhoon Missile launcher - Frag" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="4623-9a3e-995c-b533">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2D6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="➤ Typhoon Missile launcher - Krak" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="fd45-ede8-980a-669f">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Twin Multi-melta" hidden="false" id="865f-4d87-f7c3-2d77">
-              <profiles>
-                <profile name="Multi-melta" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="cfbd-9a7e-949c-be07">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Melta 2</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="91d9-cd2f-ff5-4dfc"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="23cf-ab47-baf0-6443"/>
-          </constraints>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Grey Knights Stormtalon Gunship" hidden="false" id="84ac-b9ea-921f-9082">
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="170"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="99eb-b003-79ba-7d46" id="bdd2-b942-e1e7-fe67" primary="false" name="Grey Knights Stormtalon Gunship"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="5382-8568-c025-a485" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="63f1-e6e8-f6f6-a4f0" id="939f-7e6f-26e1-da16" primary="false" name="Aircraft"/>
-        <categoryLink targetId="dbd4-63-af05-998" id="38ba-8def-1b42-231a" primary="true" name="Vehicle"/>
-        <categoryLink targetId="c619-2086-bbcf-69c9" id="a68-63ba-2371-32e9" primary="false" name="Fly"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="df4d-9039-f6aa-bdd3" primary="false" name="Imperium"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Grey Knights Stormtalon Gunship" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="cdf0-34bc-c94b-a1cd">
-          <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">20+&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">8</characteristic>
-            <characteristic name="SV" typeId="450-a17e-9d5e-29da">3+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">10</characteristic>
-            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
-            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">0</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Strafing Run" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="133a-43b1-cad3-95d6">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model makes a ranged attack that targets a unit that cannot Fly, add 1 to the Hit roll</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Side mounts" hidden="false" id="2cb7-4f18-76a4-ace1" defaultSelectionEntryId="5a7a-d41b-24c9-51f1">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7168-76a5-966b-f55e"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7bf8-16ed-1441-a82f"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Skyhammer Missile Launcher" hidden="false" id="42a3-8496-18ba-cf11">
-              <profiles>
-                <profile name="Skyhammer Missile Launcher" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="fba5-e68-2802-fbea">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D3</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Anti-Fly 2+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Typhoon Missile Launcher" hidden="false" id="b1b7-14de-f450-e212">
-              <profiles>
-                <profile name="➤ Typhoon Missile launcher - Frag" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="225a-940c-9aa1-3100">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2D6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="➤ Typhoon Missile launcher - Krak" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="1cca-21fc-4790-2b46">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Twin Heavy Bolter" hidden="false" id="b184-17b6-1949-5783">
-              <profiles>
-                <profile name="Twin Heavy Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="86eb-db88-c024-c897">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Sustained Hits 1, Twin-Linked</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Twin lascannon" hidden="false" id="76b3-5347-9b89-ee74">
-              <profiles>
-                <profile name="Twin lascannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="96d9-801-c56f-ce3b">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">12</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Twin-Linked</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <infoLinks>
-        <infoLink name="Hover" hidden="false" type="rule" id="j5i1-88tt-0c4t-t8y6" targetId="eec5-5f54-9c03-c305"/>
-        <infoLink name="Deadly Demise" hidden="false" type="rule" id="00ax-6fx9-2m0x-00xx" targetId="b68a-5ded-65ac-98c">
-          <modifiers>
-            <modifier type="append" value="D3" field="name"/>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-      <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Twin Assault Cannon" hidden="false" id="a3b1-ce0b-c208-e325">
-          <profiles>
-            <profile name="Twin Assault Cannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="58eb-ea30-6364-282f">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Twin-Linked</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e1aa-547-7081-b185"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b4cd-e52d-9521-52d5"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Armoured hull" hidden="false" id="b2cb-c9ad-9694-6241">
-          <profiles>
-            <profile name="Armoured hull" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="9584-2891-1af0-f091">
-              <characteristics>
-                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
-                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
-                <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
-                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
-                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8faa-a315-f9a7-1b5f"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f4d-2704-48ab-2eba"/>
-          </constraints>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Grey Knights Venerable Dreadnought" hidden="false" id="bd43-b303-66e0-4c10">
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="155"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="33d4-b50a-18e8-16e8" id="f8e1-2fa-e2ea-9a72" primary="false" name="Grey Knights Venerable Dreadnought"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="931c-efa7-3e1b-1d47" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="6dda-e157-334d-e93a" id="5958-2051-3d89-60b5" primary="false" name="Walker"/>
-        <categoryLink targetId="dbd4-63-af05-998" id="a760-8dc9-c644-85ba" primary="true" name="Vehicle"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="7c53-87fa-8704-af57" primary="false" name="Psyker"/>
-        <categoryLink targetId="6df-937-16bc-8c1a" id="7b61-da3b-bf9d-37f7" primary="false" name="Smoke"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="c871-7041-f747-162c" primary="false" name="Imperium"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Grey Knights Venerable Dreadnought" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="51d0-128-5b9c-c280">
-          <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">6&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">9</characteristic>
-            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">8</characteristic>
-            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
-            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">3</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Wisdom of the Ancients (Aura)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="9b3c-49ee-2ca0-7bcf">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While a friendly Grey Knights Infantry unit is within 6&quot; of this model, each time a model in that unit makes an attack, re-roll a Hit roll of 1 and re-roll a Wound roll of 1</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink name="Deadly Demise" hidden="false" type="rule" id="am5d-zh55-0x3w-17cv" targetId="b68a-5ded-65ac-98c">
-          <modifiers>
-            <modifier type="append" value="D3" field="name"/>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Right Arm" hidden="false" id="330f-6ecc-bec5-e2d2" defaultSelectionEntryId="ec97-a5a7-8739-1c3d">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Heavy plasma cannon" hidden="false" id="cac5-3183-6c96-36d1">
-              <profiles>
-                <profile name="➤ Heavy plasma cannon - Standard" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="9974-bfd2-757-865f">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D3</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">7</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="➤ Heavy plasma cannon - Supercharge" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="2327-f677-66cd-2db0">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D3</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">3</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast, Hazardous</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="f3bc-be4f-ef8b-ee2f">
-              <profiles>
-                <profile name="Multi-melta" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="87fc-a06a-e5c7-ffea">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Melta 2</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Twin lascannon" hidden="false" id="8819-174a-1f7e-2b23">
-              <profiles>
-                <profile name="Twin lascannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="4c9d-bbd1-160-44e1">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">12</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Twin-Linked</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Assault cannon" hidden="false" id="ec97-a5a7-8739-1c3d">
-              <profiles>
-                <profile name="Assault cannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="3cf-6bdf-96f9-d9f1">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9cae-875c-d630-501a"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="661b-e50e-d4fc-f07b"/>
-          </constraints>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Left Arm" hidden="false" id="e05c-d22e-3837-f4c3" defaultSelectionEntryId="2dcf-132a-2b1b-32fd">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Dreadnought combat weapon and heavy flamer" hidden="false" id="f1f5-f250-525-cff1">
-              <profiles>
-                <profile name="Dreadnought combat weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="7f08-440d-48ef-3463">
-                  <characteristics>
-                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
-                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">12</characteristic>
-                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                    <characteristic name="D" typeId="3254-9fe6-d824-513e">3</characteristic>
-                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
-                  </characteristics>
-                </profile>
-                <profile name="heavy flamer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="305d-46af-379d-5b25">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Torrent, Ignores Cover</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Dreadnought combat weapon and storm bolter" hidden="false" id="2dcf-132a-2b1b-32fd">
-              <profiles>
-                <profile name="Dreadnought combat weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="d810-2268-d24a-8922">
-                  <characteristics>
-                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
-                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">12</characteristic>
-                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                    <characteristic name="D" typeId="3254-9fe6-d824-513e">3</characteristic>
-                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
-                  </characteristics>
-                </profile>
-                <profile name="Storm bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="2f24-c972-5ed1-7874">
+                <profile id="9450-9bba-d8db-2391" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                   <characteristics>
                     <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                     <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -3286,366 +1659,249 @@
                   </characteristics>
                 </profile>
               </profiles>
+              <infoLinks>
+                <infoLink id="8516-8510-9ec5-bc73" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value="2"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Missile launcher and armoured feet" hidden="false" id="bbb0-47f7-6953-90f8">
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1a4e-5c6c-8439-14cb" name="Teleport Strike Force" hidden="false" collective="false" import="true" targetId="c440-b056-f09a-c88a" type="selectionEntryGroup"/>
+        <entryLink id="c39a-5b6b-531e-dabb" name="Warlord" hidden="false" collective="false" import="true" targetId="beae-4593-3686-1672" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="95.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3625-f9f1-122b-bf9d" name="Grand Master in Nemesis Dreadknight" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="cb71-5829-f1d5-e7da" name="Grand Master in Nemesis Dreadknight" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">8&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">8</characteristic>
+            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">13</characteristic>
+            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
+            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1ee5-63a2-6c01-e628" name="Surge of Wrath (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Once per battle round, in the Fight phase, one model from your army with this ability can use it before resolving its attacks. If it does, until the end of the phase, each time that model makes an attack that targets a Monster or Vehicle unit, you can re-roll the Hit roll, you can re-roll the Wound roll and you can re-roll the Damage roll.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="dce-9e37-9f2-5687" name="Heroism’s Favour" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time you target this model with a Stratagem, it only costs 1CP to use, even if the CP cost is higher</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="abf6-e340-d8e8-5486" name="Damaged: 1-4 Wounds Remaining" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-4 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e21a-e2fc-96f0-af31" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="0p5g-a5y9-4n8o-8d3t" name="Deadly Demise" hidden="false" targetId="b68a-5ded-65ac-98c" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="D3"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ae9f-6e8a-86ac-5830" name="Invulnerable Save (4+)" hidden="false" targetId="df6-e949-835b-ad0d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3b60-8849-d491-a2d5" name="Character" hidden="false" targetId="9cfd-1c32-585f-7d5c" primary="true"/>
+        <categoryLink id="d8d4-f8c1-b4ca-4c57" name="Vehicle" hidden="false" targetId="dbd4-63-af05-998" primary="false"/>
+        <categoryLink id="8a03-abaa-c69e-7abe" name="Walker" hidden="false" targetId="6dda-e157-334d-e93a" primary="false"/>
+        <categoryLink id="85f4-acbe-d457-b127" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="1226-741e-a60d-10b4" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="2832-4a22-ce58-de18" name="Grand Master in Nemesis Dreadknight" hidden="false" targetId="a738-1a96-db57-ba6f" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2bd0-3b67-972f-a8f6" name="Melee Weapon" hidden="false" collective="false" import="false" defaultSelectionEntryId="2eb9-3493-e588-49f4">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a82-2089-499b-22f5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a52-d62d-bc42-4638" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2eb9-3493-e588-49f4" name="Dreadfists" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
-                <profile name="➤ Missile launcher - Frag" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="d27c-85a5-1207-59cf">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="➤ Missile launcher - Krak" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="a9fc-7c8d-21f5-e12d">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
-                  </characteristics>
-                </profile>
-                <profile name="Armoured feet" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="29fc-8ca2-93d7-d35e">
+                <profile id="5d7f-39d-623-d7e4" name="Dreadfists" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
                   <characteristics>
                     <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
+                    <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
                     <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
                     <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
+                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-1</characteristic>
                     <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
                     <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
                   </characteristics>
                 </profile>
               </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="52c4-b7dd-788f-264b" name="Nemesis Greatsword" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="9704-7c3f-854b-9e25" name="➤ Nemesis Greatsword - Strike" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
+                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">10</characteristic>
+                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
+                    <characteristic name="D" typeId="3254-9fe6-d824-513e">D6</characteristic>
+                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="42ff-de93-e506-163b" name="➤ Nemesis Greatsword - Sweep" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                    <characteristic name="A" typeId="2337-daa1-6682-b110">10</characteristic>
+                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">5</characteristic>
+                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-1</characteristic>
+                    <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3b80-a160-3eec-4e00" name="Nemesis Daemon Greathammer" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="a32f-5090-8226-9c17" name="Nemesis Daemon Greathammer" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
+                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
+                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">14</characteristic>
+                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-3</characteristic>
+                    <characteristic name="D" typeId="3254-9fe6-d824-513e">D6+1</characteristic>
+                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6b86-fc58-67f3-1e"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="238d-752f-cced-8d5c"/>
-          </constraints>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-    </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Interceptor Squad" hidden="false" id="d9f7-71b7-8e67-7f44">
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="135"/>
-      </costs>
-      <modifiers>
-        <modifier type="set" value="270" field="51b2-306e-1021-d207">
-          <conditions>
-            <condition type="atLeast" value="6" field="selections" scope="d9f7-71b7-8e67-7f44" childId="model" shared="true"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="b8af-e166-8561-eb8a" primary="true" name="Infantry"/>
-        <categoryLink targetId="5a61-81ac-eb7c-a87e" id="ff4c-36c3-ff9b-a087" primary="false" name="Grenades"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="8067-1026-3d30-9eb9" primary="false" name="Imperium"/>
-        <categoryLink targetId="c619-2086-bbcf-69c9" id="803c-4e4e-3025-ee93" primary="false" name="Fly"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="b691-cc17-35e9-5c92" primary="false" name="Psyker"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="333b-3d21-7808-bac1" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="b7d3-6b00-c657-ebd7" id="2d76-f788-6240-e9bc" primary="false" name="Interceptor Squad"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Interceptor Squad" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="e87d-a435-e5a2-260c">
-          <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">12&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">4</characteristic>
-            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">2</characteristic>
-            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
-            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Personal Teleporters" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="8d05-c69c-2572-99ba">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">In your Shooting phase, after this unit has shot, if it is not within Engagement Range of one or more enemy units, it can make a Normal move of up to 6&quot; as if it were your Movement phase. If it does, until the end of the turn, this unit is not eligible to declare a charge</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="e69a-c87-618-f1b3" targetId="7cb5-dd6b-dd87-ad3b"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="1 Justicar and 4-9 Interceptors" hidden="false" id="5e2b-e394-45b-4674" defaultSelectionEntryId="2906-2dfd-6dbe-ca8">
+        <selectionEntryGroup id="5a6-d46b-4cbb-bb52" name="Ranged Weapons" hidden="false" collective="false" import="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc9b-65d8-6819-f049" type="max"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="model" import="true" name="Justicar" hidden="false" id="9ae2-cba2-3df0-81ea">
+            <selectionEntry id="deb-48a9-1858-abdc" name="Gatling Psilencer" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2324-7215-e92a-4b1b"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e341-5b62-dcfd-8b"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="726a-32bc-86bf-3e4d" type="max"/>
               </constraints>
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="cfe2-dc97-7f64-ee2b">
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
-                  </constraints>
-                  <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="263d-3404-24d1-d9db">
-                      <characteristics>
-                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                        <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
-                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
-                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="e097-4f77-7c57-4afd" targetId="e9c4-2bb8-12ee-cd1b"/>
-                  </infoLinks>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="9ac9-3c48-f753-f303">
-                  <profiles>
-                    <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="389-640a-cfb-5325">
-                      <characteristics>
-                        <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                        <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                        <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                        <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                        <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink name="Rapid Fire" hidden="false" type="rule" id="cbce-1f4c-f2f1-c18" targetId="c5c8-8b58-b8b6-7786">
-                      <modifiers>
-                        <modifier type="append" value="2" field="name"/>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b77a-f8d6-ae23-1a1d"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-                  </constraints>
-                </selectionEntry>
-              </selectionEntries>
+              <profiles>
+                <profile id="5e8d-f93d-3256-6e7d" name="Gatling Psilencer" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">12</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic, Sustained Hits 1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Interceptor" hidden="false" id="2906-2dfd-6dbe-ca8">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="4e6-6d1c-3395-59d5" collective="true">
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
-                  </constraints>
-                  <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="c32a-e96e-69a2-7b0e">
-                      <characteristics>
-                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                        <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
-                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
-                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="8b93-2673-9571-7a8" targetId="e9c4-2bb8-12ee-cd1b"/>
-                  </infoLinks>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="43d0-c61a-f6da-22a0" collective="true">
-                  <profiles>
-                    <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="2669-a603-82f5-3b05">
-                      <characteristics>
-                        <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                        <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                        <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                        <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                        <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink name="Rapid Fire" hidden="false" type="rule" id="962c-d4ec-34f7-f397" targetId="c5c8-8b58-b8b6-7786">
-                      <modifiers>
-                        <modifier type="append" value="2" field="name"/>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b77a-f8d6-ae23-1a1d"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-                  </constraints>
-                </selectionEntry>
-              </selectionEntries>
+            <selectionEntry id="8f86-8d31-fcf8-ea68" name="Heavy Incinerator" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abc4-70df-6525-ab6a" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="c0e-1834-7ad8-d882" name="Heavy Incinerator" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2D6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Torrent</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b20b-53f6-d6da-c537" name="Heavy Psycannon" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d66-7435-917a-74fd" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="25fb-aa58-5f17-686b" name="Heavy Psycannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">10</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">3</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="5" field="selections" scope="parent" shared="true" id="4458-9ace-aa41-4ab4"/>
-            <constraint type="max" value="10" field="selections" scope="parent" shared="true" id="832a-b37e-7fa1-9eb3"/>
-          </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup name="Heavy weapons" hidden="false" id="f1a1-3c53-8f3e-5a8f">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2177-38f8-8e2b-c881"/>
-              </constraints>
-              <modifiers>
-                <modifier type="set" value="2" field="2177-38f8-8e2b-c881" id="5298-bd3c-110f-6d0">
-                  <conditions>
-                    <condition type="atLeast" value="10" field="selections" scope="d9f7-71b7-8e67-7f44" childId="model" shared="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <selectionEntries>
-                <selectionEntry type="model" import="true" name="Interceptor w/ incinerator" hidden="false" id="2711-ec49-a1b2-d789">
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Incinerator" hidden="false" id="3c17-244d-6ddd-3062" collective="true">
-                      <profiles>
-                        <profile name="Incinerator" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="d504-4243-e8b0-417">
-                          <characteristics>
-                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
-                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
-                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
-                            <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                            <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Torrent</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <infoLinks>
-                        <infoLink name="Ignores Cover" hidden="false" type="rule" id="5350-f1ef-ee60-7029" targetId="4640-43e7-30b-215a"/>
-                        <infoLink name="Torrent" hidden="false" type="rule" id="ad14-b2a1-216c-9b4d" targetId="5edf-d619-23e0-9b56"/>
-                      </infoLinks>
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5e37-b7a8-d90f-e3f9"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="221a-c1e5-34b4-1ff9"/>
-                      </constraints>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <entryLinks>
-                    <entryLink import="true" name="Close combat weapon" hidden="false" type="selectionEntry" id="352f-9507-f9e3-9c7b" targetId="d0e-7460-ee7b-660f"/>
-                  </entryLinks>
-                  <constraints>
-                    <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="af8e-f74e-a928-8563"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="model" import="true" name="Interceptor w/ psilencer" hidden="false" id="dbfa-42d3-8ac9-c4dc">
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Psilencer" hidden="false" id="31f3-fb44-bc7d-8a12" collective="true">
-                      <profiles>
-                        <profile name="Psilencer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="5da7-4bd0-5f3e-d9e4">
-                          <characteristics>
-                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                            <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
-                            <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic, Sustained Hits 1</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <infoLinks>
-                        <infoLink name="Sustained Hits" hidden="false" type="rule" id="b6a6-11be-9917-a9d" targetId="1897-c22c-9597-12b1">
-                          <modifiers>
-                            <modifier type="append" value="1" field="name"/>
-                          </modifiers>
-                        </infoLink>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="73d1-1d3c-9ad1-90e4" targetId="e9c4-2bb8-12ee-cd1b"/>
-                      </infoLinks>
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="985a-b83-56e0-a974"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b4aa-3271-e6c8-3277"/>
-                      </constraints>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <entryLinks>
-                    <entryLink import="true" name="Close combat weapon" hidden="false" type="selectionEntry" id="83fe-fab0-7644-838" targetId="d0e-7460-ee7b-660f"/>
-                  </entryLinks>
-                  <constraints>
-                    <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="af8e-f74e-a928-8563"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="model" import="true" name="Interceptor w/ psycannon" hidden="false" id="ad0c-76b3-3c42-4aff">
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Psycannon" hidden="false" id="cfe5-513-b46e-9e50" collective="true">
-                      <infoLinks>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="d2fb-2ea8-7a7-9a4" targetId="e9c4-2bb8-12ee-cd1b"/>
-                      </infoLinks>
-                      <profiles>
-                        <profile name="Psycannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="1dbb-6f8c-d9e7-2da2">
-                          <characteristics>
-                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                            <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
-                            <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8c2e-72b3-9253-88ab"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f0d-e773-3252-c7dd"/>
-                      </constraints>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <entryLinks>
-                    <entryLink import="true" name="Close combat weapon" hidden="false" type="selectionEntry" id="d5f4-74d5-5b7a-58ae" targetId="d0e-7460-ee7b-660f"/>
-                  </entryLinks>
-                  <constraints>
-                    <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="af8e-f74e-a928-8563"/>
-                  </constraints>
-                </selectionEntry>
-              </selectionEntries>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
         </selectionEntryGroup>
       </selectionEntryGroups>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Kaldor Draigo" hidden="false" id="7a19-5235-692b-320d">
+      <entryLinks>
+        <entryLink id="13f3-6d13-7623-8dec" name="Teleport Strike Force" hidden="false" collective="false" import="true" targetId="c440-b056-f09a-c88a" type="selectionEntryGroup"/>
+        <entryLink id="9bc3-1965-bdc8-2169" name="Warlord" hidden="false" collective="false" import="true" targetId="beae-4593-3686-1672" type="selectionEntry"/>
+      </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="125"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="200.0"/>
       </costs>
-      <categoryLinks>
-        <categoryLink targetId="4f3a-f0f7-6647-348d" id="9a47-1367-b3dd-1318" primary="true" name="Epic Hero"/>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="6d61-f3b8-b904-a4b1" primary="false" name="Infantry"/>
-        <categoryLink targetId="9cfd-1c32-585f-7d5c" id="38e8-3e1f-cc4b-c599" primary="false" name="Character"/>
-        <categoryLink targetId="5a61-81ac-eb7c-a87e" id="4a70-5ece-cdce-924a" primary="false" name="Grenades"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="715b-8435-9a7f-e014" primary="false" name="Psyker"/>
-        <categoryLink targetId="740a-892c-8958-defa" id="d4c0-6968-e9d3-8f8d" primary="false" name="Terminator"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="6ac8-3336-cc7c-520d" primary="false" name="Imperium"/>
-        <categoryLink targetId="77b6-bfe8-648b-9fb4" id="b36b-5551-4933-6a09" primary="false" name="Kaldor Draigo"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="873-2d09-87d5-f51b" primary="false" name="Faction: Grey Knights"/>
-      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry id="7256-bb3a-3e79-31fe" name="Grand Master Voldus" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile name="Kaldor Draigo" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="6a1b-3b7e-67b5-c5ec">
+        <profile id="a37-8a28-de0e-8df5" name="Grand Master Voldus" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">5&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">5</characteristic>
             <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">7</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">6</characteristic>
             <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
           </characteristics>
         </profile>
-        <profile name="Untouchable Purity" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="cf12-2ea5-6834-5031">
+        <profile id="b513-f80c-9d48-db05" name="Sanctuary (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, models in that unit have the Feel No Pain 4+ ability against mortal wounds</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, each time an attack targets that unit, subtract 1 from the Hit roll.</characteristic>
           </characteristics>
         </profile>
-        <profile name="One With the Warp (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="c3e8-c9b9-519a-6552">
+        <profile id="bf8c-be10-e632-646d" name="Hammer Aflame (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Once per battle, when this model’s unit declares a charge in the same turn it was set up as Reinforcements using the Deep Strike ability, add 3 to the Charge roll.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model’s unit is selected to fight, you can select one enemy unit within Engagement Range of this model’s unit and roll one D6, adding 2 to the result if that unit has the Daemon keyword: on a 4-5, that enemy unit suffers D3 mortal wounds; on a 6+, that enemy unit suffers D3+3 mortal wounds.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Leader" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="d668-10b1-f5d9-9bd0">
+        <profile id="3de3-b31e-7c05-aba8" name="Leader" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
 ■ Brotherhood Terminator Squad
@@ -3654,14 +1910,28 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="64e5-ddc6-93b6-845d" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Leader" hidden="false" type="rule" id="413b-33bd-e69-59ba" targetId="b4dd-3e1f-41cb-218f"/>
-        <infoLink name="Invulnerable Save (4+)" hidden="false" type="profile" id="acfb-af78-3ddc-69f7" targetId="df6-e949-835b-ad0d"/>
+        <infoLink id="4369-e175-5ac5-231b" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="5034-3b66-4628-9ee0" name="Leader" hidden="false" targetId="b4dd-3e1f-41cb-218f" type="rule"/>
+        <infoLink id="8636-b62a-9ee4-842a" name="Invulnerable Save (4+)" hidden="false" targetId="df6-e949-835b-ad0d" type="profile"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="aabc-29c2-3bc5-2888" name="Epic Hero" hidden="false" targetId="4f3a-f0f7-6647-348d" primary="true"/>
+        <categoryLink id="dddb-e1e6-d696-9d6" name="Character" hidden="false" targetId="9cfd-1c32-585f-7d5c" primary="false"/>
+        <categoryLink id="2c13-72b8-f7b5-a66" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="false"/>
+        <categoryLink id="6ba-ee10-2110-513b" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="967c-a830-562a-a78c" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="57aa-503b-4257-a5c5" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="70aa-d5d4-4005-cdc2" name="Terminator" hidden="false" targetId="740a-892c-8958-defa" primary="false"/>
+        <categoryLink id="54be-fb0d-c179-66b0" name="Grand Master Voldus" hidden="false" targetId="472c-f807-880-b6" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="1934-6940-4a56-4ac3">
+        <selectionEntry id="90bf-576e-e6e1-34f3" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11a3-8954-73c5-f558" type="min"/>
+          </constraints>
           <profiles>
-            <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="c564-12d6-1b9d-5e06">
+            <profile id="f8f5-d926-d76f-9404" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -3674,291 +1944,1825 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Rapid Fire" hidden="false" type="rule" id="24a0-3ca0-de94-f9e9" targetId="c5c8-8b58-b8b6-7786">
+            <infoLink id="6ac7-e98f-acea-61aa" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
               <modifiers>
-                <modifier type="append" value="2" field="name"/>
+                <modifier type="append" field="name" value="2"/>
               </modifiers>
             </infoLink>
           </infoLinks>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="11a3-8954-73c5-f558"/>
-          </constraints>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Scourging" hidden="false" id="8804-9b5d-14e7-5e2d">
-          <profiles>
-            <profile name="Scourging" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="2874-4a20-ee8c-ed97">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Anti-Daemon 2+, Ignores Cover, Psychic</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
+        <selectionEntry id="6b5f-a7fc-2a1b-b24e" name="Malleus Argyrum" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6338-b970-2315-d2a"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d220-9471-922f-f613"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74bd-1b90-ed9e-d18e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc94-131a-657e-9206" type="min"/>
           </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="The Titansword" hidden="false" id="b9fb-d4e1-34ae-d02f">
           <profiles>
-            <profile name="The Titansword" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="232a-4043-3ee0-f92">
+            <profile id="9c20-33ed-5139-f2df" name="Malleus Argyrum" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
+                <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
                 <characteristic name="WS" typeId="95d1-95f-45b4-11d6">2+</characteristic>
-                <characteristic name="S" typeId="ab33-d393-96ce-ccba">8</characteristic>
-                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-4</characteristic>
+                <characteristic name="S" typeId="ab33-d393-96ce-ccba">10</characteristic>
+                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
                 <characteristic name="D" typeId="3254-9fe6-d824-513e">3</characteristic>
-                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Anti-Daemon 2+, Psychic</characteristic>
+                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
               </characteristics>
             </profile>
           </profiles>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="752f-dcfd-a273-b1f4"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2015-9370-77a-aeb1"/>
-          </constraints>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="11ba-e4a9-aa6-2721" targetId="beae-4593-3686-1672"/>
+        <entryLink id="b226-1312-fee6-ae5e" name="Warlord" hidden="false" collective="false" import="true" targetId="beae-4593-3686-1672" type="selectionEntry"/>
       </entryLinks>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Nemesis Dreadknight" hidden="false" id="5458-a458-c51d-c4e9">
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="185"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="95.0"/>
       </costs>
-      <categoryLinks>
-        <categoryLink targetId="8083-7b7a-c9d7-fd31" id="87ef-bf19-85f0-d3fe" primary="false" name="Nemesis Dreadknight"/>
-        <categoryLink targetId="dbd4-63-af05-998" id="5ab4-220c-a69b-9f99" primary="true" name="Vehicle"/>
-        <categoryLink targetId="6dda-e157-334d-e93a" id="51dd-535c-7f1b-c027" primary="false" name="Walker"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="6fcb-25d8-c666-ac6f" primary="false" name="Psyker"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="46db-601-55fc-84d0" primary="false" name="Imperium"/>
-      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry id="512d-b972-911e-4cac" name="Grey Knights Land Raider" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile name="Nemesis Dreadknight" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="a1ef-3a29-210b-de07">
+        <profile id="5eb5-ef56-7823-faa0" name="Grey Knights Land Raider" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">8&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">8</characteristic>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">10&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">12</characteristic>
             <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">13</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">16</characteristic>
             <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
-            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">4</characteristic>
+            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">5</characteristic>
           </characteristics>
         </profile>
-        <profile name="Empyric Reprisal (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="c53f-7fdc-438d-5dcd">
+        <profile id="c1d5-950b-12b6-7201" name="Assault Ramp" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model is eligible to shoot and declare a charge in a turn in which it Advanced or Fell Back.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a unit disembarks from this model after it has made a Normal move, that unit is still eligible to declare a charge this turn.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Damaged: 1-4 Wounds Remaining" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="6980-2489-73f9-24ed">
+        <profile id="e6a-44ad-c190-51c5" name="Damaged: 1-5 Wounds Remaining" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-4 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-5 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="511a-e5a0-5e4f-89e4" name="Grey Knights Land Raider" hidden="false" typeId="74f8-5443-9d6d-1f1e" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="30f2-be70-861d-1b84">This model has a transport capacity of 12 Grey Knights Infantry models. Each Terminator model takes up the space of 2 models</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="f7cf-34d4-c47-b12b" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Deadly Demise" hidden="false" type="rule" id="zz44-ab36-7h9l-2b6j" targetId="b68a-5ded-65ac-98c">
+        <infoLink id="z5h8-a351-4t8o-p1c4" name="Deadly Demise" hidden="false" targetId="b68a-5ded-65ac-98c" type="rule">
           <modifiers>
-            <modifier type="append" value="D3" field="name"/>
+            <modifier type="append" field="name" value="D6"/>
           </modifiers>
         </infoLink>
-        <infoLink name="Invulnerable Save (4+)" hidden="false" type="profile" id="9c1d-310d-3e87-e513" targetId="df6-e949-835b-ad0d"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="22e9-f614-a41f-1ec9" name="Vehicle" hidden="false" targetId="dbd4-63-af05-998" primary="true"/>
+        <categoryLink id="48d8-c3b9-26d8-5dd" name="Smoke" hidden="false" targetId="6df-937-16bc-8c1a" primary="false"/>
+        <categoryLink id="a6c7-5a01-5363-49b2" name="Transport" hidden="false" targetId="75e8-57c4-40e3-1817" primary="false"/>
+        <categoryLink id="2747-434a-c047-c33a" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="f13d-271c-abfb-fa0" name="Grey Knights Land Raider" hidden="false" targetId="adfb-534b-3eb7-2781" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ff0-5d7d-c73b-9c5f" name="Godhammer Lascannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b554-1c9a-2d88-57d1" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d7c-bd88-37b9-1210" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="da8a-8a15-3669-95d0" name="Godhammer Lascannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">12</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+1</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b9c1-621d-4e2c-ec53" name="Hunter-killer Missile" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6d5-9a69-e0a6-bd98" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9d99-67d2-33bb-e550" name="Hunter-killer Missile" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">14</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">One Shot</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="45b2-6705-e24e-4378" name="Multi-melta" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f07-a7a3-8139-1a13" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9a39-e37c-3cda-db11" name="Multi-melta" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Melta 2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a267-d6e8-d2f9-e9e5" name="Twin Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29ec-e7e8-f0dc-dec7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6775-ae10-22c-bae5" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="559a-2e12-8e8c-53af" name="Twin Heavy Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Sustained Hits 1, Twin-Linked</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a3fa-1259-f3cb-f873" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fdf5-68b9-b99e-beb9" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="ae9a-7702-d08d-f8f8" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value="2"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cfd1-5e6a-36c3-7997" name="Armoured tracks" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8faa-a315-f9a7-1b5f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f4d-2704-48ab-2eba" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c515-8bde-e0ab-5c4e" name="Armoured tracks" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
+                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
+                <characteristic name="S" typeId="ab33-d393-96ce-ccba">8</characteristic>
+                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
+                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="240.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4c63-cca-8d26-6330" name="Grey Knights Land Raider Crusader" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="88aa-3a4d-4ff3-1b4c" name="Grey Knights Land Raider Crusader" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">12&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">12</characteristic>
+            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">16</characteristic>
+            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
+            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c059-84a-5bf2-dcbf" name="Assault Ramp" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a unit disembarks from this model after it has made a Normal move, that unit is still eligible to declare a charge this turn.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cfb3-a59a-4eb1-1079" name="Damaged: 1-5 Wounds Remaining" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-5 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4c37-b59b-e445-d686" name="Grey Knights Land Raider Crusader" hidden="false" typeId="74f8-5443-9d6d-1f1e" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="30f2-be70-861d-1b84">This model has a transport capacity of 16 Grey Knights Infantry models. Each Terminator model takes up the space of 2 models</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="z9y5-0m4z-1t7o-a160" name="Deadly Demise" hidden="false" targetId="b68a-5ded-65ac-98c" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="D6"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6883-f1e6-130c-1042" name="Vehicle" hidden="false" targetId="dbd4-63-af05-998" primary="true"/>
+        <categoryLink id="e0fc-d4c8-8e98-510d" name="Transport" hidden="false" targetId="75e8-57c4-40e3-1817" primary="false"/>
+        <categoryLink id="ba68-5ea0-4f9e-2dd4" name="Smoke" hidden="false" targetId="6df-937-16bc-8c1a" primary="false"/>
+        <categoryLink id="112d-a130-24a8-1ac4" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="cee7-cbe9-4b88-6fe4" name="Grenades" hidden="false" targetId="5a61-81ac-eb7c-a87e" primary="false"/>
+        <categoryLink id="fd99-568c-8e1-3c50" name="Grey Knights Land Raider Crusader" hidden="false" targetId="4a04-1f1b-8ffb-b183" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3e8f-4409-e8e1-e0f6" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a2c2-3246-5b1d-ec4" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="dde4-1e5b-532e-c5ac" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value="2"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9b02-db16-f3e1-2ba6" name="Multi-melta" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f07-a7a3-8139-1a13" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fe87-8a70-818d-e92a" name="Multi-melta" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Melta 2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="826e-a7e2-6487-697f" name="Hunter-killer Missile" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6d5-9a69-e0a6-bd98" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a397-5107-56e3-186e" name="Hunter-killer Missile" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">14</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">One Shot</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d6c2-e486-b6f-dcf3" name="Armoured tracks" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8faa-a315-f9a7-1b5f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f4d-2704-48ab-2eba" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e8f7-2c18-6415-b114" name="Armoured tracks" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
+                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
+                <characteristic name="S" typeId="ab33-d393-96ce-ccba">8</characteristic>
+                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
+                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ed38-3e46-5c38-39d9" name="Hurricane Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e83-5b45-e013-7181" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e95e-dde9-eb95-6e6f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e382-718e-f1fa-aab7" name="Hurricane Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 6, Twin-Linked</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f061-6db7-ce1a-d3cb" name="Twin Assault Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1aa-547-7081-b185" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4cd-e52d-9521-52d5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8057-da99-6365-6cc2" name="Twin Assault Cannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Twin-Linked</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="230.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ada7-eb0b-c920-d77f" name="Grey Knights Land Raider Redeemer" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="36a8-d1b9-a5e8-b70f" name="Grey Knights Land Raider Redeemer" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">12&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">12</characteristic>
+            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">16</characteristic>
+            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
+            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="203b-c2a4-cba0-ee49" name="Grey Knights Land Raider Redeemer" hidden="false" typeId="74f8-5443-9d6d-1f1e" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="30f2-be70-861d-1b84">This model has a transport capacity of 14 Grey Knights Infantry models. Each Terminator model takes up the space of 2 models</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="35e9-caef-a97f-a190" name="Assault Ramp" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a unit disembarks from this model after it has made a Normal move, that unit is still eligible to declare a charge this turn.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="df47-ae30-f628-3d25" name="Damaged: 1-5 Wounds Remaining" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-5 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6n9a-b5m0-z02g-7hrb" name="Deadly Demise" hidden="false" targetId="b68a-5ded-65ac-98c" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="D6"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f63-e411-a94b-b671" name="Grey Knights Land Raider Redeemer" hidden="false" targetId="51dd-461e-1657-1017" primary="false"/>
+        <categoryLink id="15a4-b6ff-d470-4278" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="b9af-488c-f33c-ff4e" name="Grenades" hidden="false" targetId="5a61-81ac-eb7c-a87e" primary="false"/>
+        <categoryLink id="dbbe-40e3-b6f9-3f35" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="67c0-7de9-2852-1d4c" name="Vehicle" hidden="false" targetId="dbd4-63-af05-998" primary="true"/>
+        <categoryLink id="692c-54c1-472f-41d3" name="Transport" hidden="false" targetId="75e8-57c4-40e3-1817" primary="false"/>
+        <categoryLink id="8e23-882d-4c2a-b3ec" name="Smoke" hidden="false" targetId="6df-937-16bc-8c1a" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7bf6-9fd5-5cd5-c1a6" name="Twin Assault Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1aa-547-7081-b185" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4cd-e52d-9521-52d5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e8a9-8b39-81d8-a8a6" name="Twin Assault Cannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Twin-Linked</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c05d-98a6-4648-fb81" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ffd6-96d3-1e12-ec10" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="1dcf-8a74-283c-1468" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value="2"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8dd8-efec-de14-c678" name="Multi-melta" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f07-a7a3-8139-1a13" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e882-abaf-59a2-bbaf" name="Multi-melta" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Melta 2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3917-9b44-e861-6f17" name="Hunter-killer Missile" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6d5-9a69-e0a6-bd98" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9822-21fd-941-a5cf" name="Hunter-killer Missile" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">14</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">One Shot</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8ae2-ca88-19cf-2378" name="Armoured tracks" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8faa-a315-f9a7-1b5f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f4d-2704-48ab-2eba" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="285d-4150-192f-12a4" name="Armoured tracks" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
+                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
+                <characteristic name="S" typeId="ab33-d393-96ce-ccba">8</characteristic>
+                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
+                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="47d2-bdb6-a769-cd0f" name="Flamestorm Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c50-83ba-b6b2-e133" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a255-68a7-2872-34a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f1a0-8910-1680-5177" name="Flamestorm Cannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6+3</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Torrent</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="260.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="841f-98b-fbf3-c8ee" name="Grey Knights Razorback" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="44b5-6d17-8379-c609" name="Grey Knights Razorback" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">12&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">9</characteristic>
+            <characteristic name="SV" typeId="450-a17e-9d5e-29da">3+</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">10</characteristic>
+            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
+            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="69f9-2b19-561e-aeb5" name="Grey Knights Razorback" hidden="false" typeId="74f8-5443-9d6d-1f1e" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="30f2-be70-861d-1b84">This model has a transport capacity of 6 Grey Knights Infantry models. It cannot transport Terminator models.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b9fd-80d9-a165-1812" name="Fire Support" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">In your Shooting phase, after this model has shot, select one enemy unit it scored one or more hits against this phase. Until the end of the phase, each time a friendly model that disembarked from this Transport this turn makes an attack that targets that enemy unit, you can re-roll the Wound roll</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="p276-0a8z-1m59-m5x8" name="Deadly Demise" hidden="false" targetId="b68a-5ded-65ac-98c" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="D3"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1f3-5245-3cc2-e6cf" name="Grey Knights Razorback" hidden="false" targetId="88ad-5f29-ba09-9427" primary="false"/>
+        <categoryLink id="d083-4c1a-236a-7dfd" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="a381-cb06-2fe0-9834" name="Dedicated Transport" hidden="false" targetId="ba07-411c-2832-1f79" primary="true"/>
+        <categoryLink id="5f4e-96f1-fa70-7e18" name="Vehicle" hidden="false" targetId="dbd4-63-af05-998" primary="false"/>
+        <categoryLink id="4b6e-cc44-6aa1-9863" name="Transport" hidden="false" targetId="75e8-57c4-40e3-1817" primary="false"/>
+        <categoryLink id="90a2-3fed-cf2b-be5a" name="Smoke" hidden="false" targetId="6df-937-16bc-8c1a" primary="false"/>
+        <categoryLink id="f70b-577c-5b88-829a" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c22-6c03-9fcc-6a56" name="Armoured tracks" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8faa-a315-f9a7-1b5f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f4d-2704-48ab-2eba" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5cf3-d55c-1b15-a423" name="Armoured tracks" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
+                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
+                <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
+                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
+                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e66a-945e-272a-74a2" name="Hunter-killer Missile" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6d5-9a69-e0a6-bd98" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5b78-4de-2a6a-9a68" name="Hunter-killer Missile" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">14</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">One Shot</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="27b9-1a3e-1c8f-4918" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="330d-3463-fa04-568" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="72d9-301-a0d2-f02e" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value="2"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup name="Melee Weapon" hidden="false" id="e21a-cac0-9dfe-5ee2" defaultSelectionEntryId="2eb9-3493-e588-49f4">
+        <selectionEntryGroup id="2831-c0e-a552-952a" name="Weapon Option" hidden="false" collective="false" import="false" defaultSelectionEntryId="4a1e-bc03-a5be-21c3">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="379c-a140-c939-189" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9a-6186-7f85-d09" type="max"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Dreadfists" hidden="false" id="9f7f-ad95-cb89-3df6">
+            <selectionEntry id="4a1e-bc03-a5be-21c3" name="Twin Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
-                <profile name="Dreadfists" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="47a-1263-759-50b7">
+                <profile id="f5fc-169-bfb2-6bd8" name="Twin Heavy Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Sustained Hits 1, Twin-Linked</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d90b-ac39-5ce5-4687" name="Twin Assault Cannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="84e9-ed79-ed6c-e524" name="Twin Assault Cannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Twin-Linked</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c756-4d3d-897-c0b0" name="Twin lascannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="4053-cc1c-69a5-911f" name="Twin lascannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">12</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Twin-Linked</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="85.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5ffd-f698-a1bb-fba7" name="Grey Knights Rhino" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="ceee-2a3f-1c1-3151" name="Grey Knights Rhino" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">12&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">9</characteristic>
+            <characteristic name="SV" typeId="450-a17e-9d5e-29da">3+</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">10</characteristic>
+            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
+            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4b87-568-feeb-bc57" name="Grey Knights Rhino" hidden="false" typeId="74f8-5443-9d6d-1f1e" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="30f2-be70-861d-1b84">This model has a transport capacity of 12 Grey Knights Infantry models. It cannot transport Terminator models.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3355-18b8-ee22-87f9" name="Self Repair" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">At the start of your Command phase, this model regains 1 lost wound.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6m2i-0z8d-ci38-mt39" name="Deadly Demise" hidden="false" targetId="b68a-5ded-65ac-98c" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="D3"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ca5a-1654-b3a5-f753" name="Firing Deck" hidden="false" targetId="13b2-6518-dab3-7ea1" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="2"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bcf8-779b-c8c8-53b6" name="Grey Knights Rhino" hidden="false" targetId="5ced-f445-91c2-a55e" primary="false"/>
+        <categoryLink id="efb5-d648-92d5-5651" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="c3d-3af1-1364-be04" name="Transport" hidden="false" targetId="75e8-57c4-40e3-1817" primary="false"/>
+        <categoryLink id="94cf-eb82-d99-396d" name="Vehicle" hidden="false" targetId="dbd4-63-af05-998" primary="false"/>
+        <categoryLink id="1cf4-f88-9548-981e" name="Dedicated Transport" hidden="false" targetId="ba07-411c-2832-1f79" primary="true"/>
+        <categoryLink id="6a2-5785-3e72-cb14" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="d93f-65ef-ae59-b374" name="Smoke" hidden="false" targetId="6df-937-16bc-8c1a" primary="false"/>
+        <categoryLink id="91fd-28ef-15c1-31b" name="Rhino" hidden="false" targetId="50a2-5557-84bb-ca4d" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e994-7f6f-3786-b476" name="Armoured tracks" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8faa-a315-f9a7-1b5f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f4d-2704-48ab-2eba" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c5e0-c829-98a5-880a" name="Armoured tracks" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
+                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
+                <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
+                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
+                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="37c7-1fb-eb45-8c5b" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d1e-fdff-c246-9bc4" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="5349-e445-419-cb09" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="fc29-1eca-e71c-d93" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value="2"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9ee6-9eda-cd98-cd4a" name="Hunter-killer Missile" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6d5-9a69-e0a6-bd98" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d74a-b284-964a-c781" name="Hunter-killer Missile" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">14</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">One Shot</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="75.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fa-e288-2107-d22e" name="Grey Knights Stormhawk Interceptor" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="6013-ab9b-5543-f992" name="Grey Knights Stormhawk Interceptor" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">20+&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">9</characteristic>
+            <characteristic name="SV" typeId="450-a17e-9d5e-29da">3+</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">10</characteristic>
+            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
+            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f531-b188-9179-2f5a" name="Interceptor" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model makes a ranged attack that targets a unit that can Fly, add 1 to the Hit roll</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="j5i1-0z0e-6713-8r5t" name="Hover" hidden="false" targetId="eec5-5f54-9c03-c305" type="rule"/>
+        <infoLink id="a9dk-t59s-c92e-zp4d" name="Deadly Demise" hidden="false" targetId="b68a-5ded-65ac-98c" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="D3"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9d7c-5600-b20-bd83" name="Grey Knights Stormhawk Interceptor" hidden="false" targetId="82f-4771-c58e-1755" primary="false"/>
+        <categoryLink id="574b-ca51-2b5d-5dfc" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="b5fa-157c-ca4c-d806" name="Vehicle" hidden="false" targetId="dbd4-63-af05-998" primary="true"/>
+        <categoryLink id="94c9-f0c7-afb7-8ddb" name="Aircraft" hidden="false" targetId="63f1-e6e8-f6f6-a4f0" primary="false"/>
+        <categoryLink id="b0e4-9547-be15-58ae" name="Fly" hidden="false" targetId="c619-2086-bbcf-69c9" primary="false"/>
+        <categoryLink id="6165-3410-7c8b-6167" name="Smoke" hidden="false" targetId="6df-937-16bc-8c1a" primary="false"/>
+        <categoryLink id="22cf-6b26-3e8d-3c98" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b040-e71a-dd4f-98f1" name="Twin Assault Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1aa-547-7081-b185" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4cd-e52d-9521-52d5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a6cc-bd0d-a736-691e" name="Twin Assault Cannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Twin-Linked</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="527c-c236-4376-640b" name="Armoured hull" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8faa-a315-f9a7-1b5f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f4d-2704-48ab-2eba" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4c1a-4184-fbae-54f9" name="Armoured hull" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
+                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
+                <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
+                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
+                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bd6d-2b6c-4d2d-ccfb" name="Nose Gun" hidden="false" collective="false" import="false" defaultSelectionEntryId="8d15-f7a6-1804-ae58">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="351e-fe18-2863-997b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2911-8e75-71a5-1a9d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8d15-f7a6-1804-ae58" name="Las-Talon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="fb9-de3-ed8-a4f9" name="Las-Talon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">10</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d9eb-e3b3-8a2-adba" name="Icarus Stormcannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="6530-32e9-6176-f896" name="Icarus Stormcannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">7</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Anti-Fly 2+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3768-739c-af00-fde4" name="Side mounts" hidden="false" collective="false" import="false" defaultSelectionEntryId="5a7a-d41b-24c9-51f1">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7168-76a5-966b-f55e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bf8-16ed-1441-a82f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5a7a-d41b-24c9-51f1" name="Skyhammer Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="c43a-1763-f25b-ec54" name="Skyhammer Missile Launcher" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D3</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Anti-Fly 2+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ff7c-b295-5e15-57c" name="Typhoon Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="2da1-5c5b-2397-87d8" name="➤ Typhoon Missile launcher - Frag" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2D6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="e20e-50d1-b8a8-746b" name="➤ Typhoon Missile launcher - Krak" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d93c-7e31-c682-ea2e" name="Twin Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="3f09-8f41-984c-ef48" name="Twin Heavy Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Sustained Hits 1, Twin-Linked</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="160.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2efe-459b-9562-e7a9" name="Grey Knights Stormraven Gunship" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="f8c1-1eb7-cf09-7717" name="Grey Knights Stormraven Gunship" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">20+&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">10</characteristic>
+            <characteristic name="SV" typeId="450-a17e-9d5e-29da">3+</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">14</characteristic>
+            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
+            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c534-53bb-4d73-23d2" name="Armoured Resilience" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time an attack is allocated to this model, subtract 1 from the Damage characteristic of that attack</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5d24-6acb-2ed-b67" name="Damaged: 1-5 Wounds Remaining" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-5 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="146c-72b7-bd76-e9ba" name="Grey Knights Stormraven Gunship" hidden="false" typeId="74f8-5443-9d6d-1f1e" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="30f2-be70-861d-1b84">This model has a transport capacity of 12 Grey Knights Infantry models and 1 Grey Knights Venerable Dreadnought model. Each Terminator model takes up the space of 2 models</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="j5i1-126f-6802-m7i3" name="Hover" hidden="false" targetId="eec5-5f54-9c03-c305" type="rule"/>
+        <infoLink id="0b4l-bx92-m30d-0x4d" name="Deadly Demise" hidden="false" targetId="b68a-5ded-65ac-98c" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="D6"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9dfe-1abf-8eb0-50f0" name="Grey Knights Stormraven Gunship" hidden="false" targetId="54b8-5bba-f749-e5ef" primary="false"/>
+        <categoryLink id="511-5629-2d1f-367" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="a5e5-37e-53e-34b5" name="Aircraft" hidden="false" targetId="63f1-e6e8-f6f6-a4f0" primary="false"/>
+        <categoryLink id="ebc8-8b9a-701d-22f5" name="Vehicle" hidden="false" targetId="dbd4-63-af05-998" primary="true"/>
+        <categoryLink id="45cf-409f-6bae-bb81" name="Transport" hidden="false" targetId="75e8-57c4-40e3-1817" primary="false"/>
+        <categoryLink id="489d-9fde-9665-edd1" name="Fly" hidden="false" targetId="c619-2086-bbcf-69c9" primary="false"/>
+        <categoryLink id="3bd9-2688-11f9-27ff" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="aef0-cb77-f237-ca6a" name="Hurricane Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e95e-dde9-eb95-6e6f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="452e-dfff-8d5d-ff0d" name="Hurricane Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 6, Twin-Linked</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b2ea-93b8-8009-b652" name="Stormstrike missile launcher" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ed2-d4f5-f24d-77c2" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b82b-2ab0-a3-f771" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6340-bb29-ab5e-a0c9" name="Stormstrike missile launcher" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">10</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+2</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="67d-4c1b-48eb-1cfd" name="Top Turret" hidden="false" collective="false" import="false" defaultSelectionEntryId="f1b9-fd0a-b087-2e4c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48b1-7ad9-2a2e-325b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3521-b91f-ec70-7c96" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f1b9-fd0a-b087-2e4c" name="Twin Assault Cannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="6045-318b-104-ea21" name="Twin Assault Cannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Twin-Linked</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="716a-c91c-3254-d60c" name="Twin lascannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="3836-8269-1ad3-92dc" name="Twin lascannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">12</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Twin-Linked</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f72d-9efb-2c8e-e95c" name="Twin Heavy plasma cannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="c6d3-899c-3edf-dd94" name="➤ Twin Heavy plasma cannon - Standard" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">7</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast, Twin-Linked</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="56b1-1619-dbc6-c1d" name="➤ Twin Heavy plasma cannon - Supercharge" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">3</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast, Hazardous, Twin-Linked</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f56d-5657-3a1a-cfe7" name="Nose Mount" hidden="false" collective="false" import="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91d9-cd2f-ff5-4dfc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23cf-ab47-baf0-6443" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="716a-979a-662c-5fae" name="Twin Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="6a9e-e5f7-870e-29bc" name="Twin Heavy Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Sustained Hits 1, Twin-Linked</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="843-6b91-5f47-c3e8" name="Typhoon Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="4623-9a3e-995c-b533" name="➤ Typhoon Missile launcher - Frag" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2D6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="fd45-ede8-980a-669f" name="➤ Typhoon Missile launcher - Krak" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="865f-4d87-f7c3-2d77" name="Twin Multi-melta" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="cfbd-9a7e-949c-be07" name="Multi-melta" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Melta 2</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="265.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="84ac-b9ea-921f-9082" name="Grey Knights Stormtalon Gunship" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="cdf0-34bc-c94b-a1cd" name="Grey Knights Stormtalon Gunship" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">20+&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">8</characteristic>
+            <characteristic name="SV" typeId="450-a17e-9d5e-29da">3+</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">10</characteristic>
+            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
+            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="133a-43b1-cad3-95d6" name="Strafing Run" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model makes a ranged attack that targets a unit that cannot Fly, add 1 to the Hit roll</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="j5i1-88tt-0c4t-t8y6" name="Hover" hidden="false" targetId="eec5-5f54-9c03-c305" type="rule"/>
+        <infoLink id="00ax-6fx9-2m0x-00xx" name="Deadly Demise" hidden="false" targetId="b68a-5ded-65ac-98c" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="D3"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bdd2-b942-e1e7-fe67" name="Grey Knights Stormtalon Gunship" hidden="false" targetId="99eb-b003-79ba-7d46" primary="false"/>
+        <categoryLink id="5382-8568-c025-a485" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="939f-7e6f-26e1-da16" name="Aircraft" hidden="false" targetId="63f1-e6e8-f6f6-a4f0" primary="false"/>
+        <categoryLink id="38ba-8def-1b42-231a" name="Vehicle" hidden="false" targetId="dbd4-63-af05-998" primary="true"/>
+        <categoryLink id="a68-63ba-2371-32e9" name="Fly" hidden="false" targetId="c619-2086-bbcf-69c9" primary="false"/>
+        <categoryLink id="df4d-9039-f6aa-bdd3" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a3b1-ce0b-c208-e325" name="Twin Assault Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1aa-547-7081-b185" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4cd-e52d-9521-52d5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="58eb-ea30-6364-282f" name="Twin Assault Cannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Twin-Linked</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b2cb-c9ad-9694-6241" name="Armoured hull" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8faa-a315-f9a7-1b5f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f4d-2704-48ab-2eba" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9584-2891-1af0-f091" name="Armoured hull" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
+                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
+                <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
+                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
+                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2cb7-4f18-76a4-ace1" name="Side mounts" hidden="false" collective="false" import="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7168-76a5-966b-f55e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bf8-16ed-1441-a82f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="42a3-8496-18ba-cf11" name="Skyhammer Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="fba5-e68-2802-fbea" name="Skyhammer Missile Launcher" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D3</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Anti-Fly 2+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b1b7-14de-f450-e212" name="Typhoon Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="225a-940c-9aa1-3100" name="➤ Typhoon Missile launcher - Frag" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2D6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="1cca-21fc-4790-2b46" name="➤ Typhoon Missile launcher - Krak" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b184-17b6-1949-5783" name="Twin Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="86eb-db88-c024-c897" name="Twin Heavy Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Sustained Hits 1, Twin-Linked</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="76b3-5347-9b89-ee74" name="Twin lascannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="96d9-801-c56f-ce3b" name="Twin lascannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">12</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Twin-Linked</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="170.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bd43-b303-66e0-4c10" name="Grey Knights Venerable Dreadnought" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="51d0-128-5b9c-c280" name="Grey Knights Venerable Dreadnought" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">6&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">9</characteristic>
+            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">8</characteristic>
+            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
+            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9b3c-49ee-2ca0-7bcf" name="Wisdom of the Ancients (Aura)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While a friendly Grey Knights Infantry unit is within 6&quot; of this model, each time a model in that unit makes an attack, re-roll a Hit roll of 1 and re-roll a Wound roll of 1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="am5d-zh55-0x3w-17cv" name="Deadly Demise" hidden="false" targetId="b68a-5ded-65ac-98c" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="D3"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f8e1-2fa-e2ea-9a72" name="Grey Knights Venerable Dreadnought" hidden="false" targetId="33d4-b50a-18e8-16e8" primary="false"/>
+        <categoryLink id="931c-efa7-3e1b-1d47" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="5958-2051-3d89-60b5" name="Walker" hidden="false" targetId="6dda-e157-334d-e93a" primary="false"/>
+        <categoryLink id="a760-8dc9-c644-85ba" name="Vehicle" hidden="false" targetId="dbd4-63-af05-998" primary="true"/>
+        <categoryLink id="7c53-87fa-8704-af57" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="7b61-da3b-bf9d-37f7" name="Smoke" hidden="false" targetId="6df-937-16bc-8c1a" primary="false"/>
+        <categoryLink id="c871-7041-f747-162c" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="330f-6ecc-bec5-e2d2" name="Right Arm" hidden="false" collective="false" import="false" defaultSelectionEntryId="ec97-a5a7-8739-1c3d">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cae-875c-d630-501a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="661b-e50e-d4fc-f07b" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="cac5-3183-6c96-36d1" name="Heavy plasma cannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="9974-bfd2-757-865f" name="➤ Heavy plasma cannon - Standard" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D3</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">7</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="2327-f677-66cd-2db0" name="➤ Heavy plasma cannon - Supercharge" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D3</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">3</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast, Hazardous</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f3bc-be4f-ef8b-ee2f" name="Multi-melta" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="87fc-a06a-e5c7-ffea" name="Multi-melta" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Melta 2</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8819-174a-1f7e-2b23" name="Twin lascannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="4c9d-bbd1-160-44e1" name="Twin lascannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">12</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Twin-Linked</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ec97-a5a7-8739-1c3d" name="Assault cannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="3cf-6bdf-96f9-d9f1" name="Assault cannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e05c-d22e-3837-f4c3" name="Left Arm" hidden="false" collective="false" import="false" defaultSelectionEntryId="2dcf-132a-2b1b-32fd">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b86-fc58-67f3-1e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="238d-752f-cced-8d5c" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f1f5-f250-525-cff1" name="Dreadnought combat weapon and heavy flamer" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="7f08-440d-48ef-3463" name="Dreadnought combat weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
                   <characteristics>
                     <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                    <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
+                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
+                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">12</characteristic>
+                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
+                    <characteristic name="D" typeId="3254-9fe6-d824-513e">3</characteristic>
+                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
+                  </characteristics>
+                </profile>
+                <profile id="305d-46af-379d-5b25" name="heavy flamer" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Torrent, Ignores Cover</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2dcf-132a-2b1b-32fd" name="Dreadnought combat weapon and storm bolter" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="d810-2268-d24a-8922" name="Dreadnought combat weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
+                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">12</characteristic>
+                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
+                    <characteristic name="D" typeId="3254-9fe6-d824-513e">3</characteristic>
+                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
+                  </characteristics>
+                </profile>
+                <profile id="2f24-c972-5ed1-7874" name="Storm bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bbb0-47f7-6953-90f8" name="Missile launcher and armoured feet" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="d27c-85a5-1207-59cf" name="➤ Missile launcher - Frag" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="a9fc-7c8d-21f5-e12d" name="➤ Missile launcher - Krak" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c"/>
+                  </characteristics>
+                </profile>
+                <profile id="29fc-8ca2-93d7-d35e" name="Armoured feet" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
                     <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
                     <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-1</characteristic>
+                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
                     <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
                     <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
                   </characteristics>
                 </profile>
               </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Nemesis Greatsword" hidden="false" id="c87c-a41d-9640-aa1e">
-              <profiles>
-                <profile name="➤ Nemesis Greatsword - Strike" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="72e7-ba02-c736-caf7">
-                  <characteristics>
-                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
-                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">10</characteristic>
-                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                    <characteristic name="D" typeId="3254-9fe6-d824-513e">D6</characteristic>
-                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-                  </characteristics>
-                </profile>
-                <profile name="➤ Nemesis Greatsword - Sweep" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="5047-d408-9c6d-9b63">
-                  <characteristics>
-                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                    <characteristic name="A" typeId="2337-daa1-6682-b110">10</characteristic>
-                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">5</characteristic>
-                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-1</characteristic>
-                    <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
-                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Nemesis Daemon Greathammer" hidden="false" id="6fe6-97cc-6f34-b23e">
-              <profiles>
-                <profile name="Nemesis Daemon Greathammer" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="967e-5402-f748-5ec4">
-                  <characteristics>
-                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
-                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
-                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">14</characteristic>
-                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-3</characteristic>
-                    <characteristic name="D" typeId="3254-9fe6-d824-513e">D6+1</characteristic>
-                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8a82-2089-499b-22f5"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5a52-d62d-bc42-4638"/>
-          </constraints>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Ranged Weapons" hidden="false" id="88f7-cb71-5700-82da">
-          <constraints>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="fc9b-65d8-6819-f049"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Gatling Psilencer" hidden="false" id="eea8-d667-691b-336c">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="726a-32bc-86bf-3e4d"/>
-              </constraints>
-              <profiles>
-                <profile name="Gatling Psilencer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="61d-b7d7-761c-739b">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">12</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic, Sustained Hits 1</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Heavy Incinerator" hidden="false" id="5e54-2e6d-48a1-5b6e">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="abc4-70df-6525-ab6a"/>
-              </constraints>
-              <profiles>
-                <profile name="Heavy Incinerator" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="2de9-9b67-647a-e973">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2D6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Torrent</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Heavy Psycannon" hidden="false" id="d93e-2aa1-5f95-72a8">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4d66-7435-917a-74fd"/>
-              </constraints>
-              <profiles>
-                <profile name="Heavy Psycannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="e63a-efa4-e920-d2a0">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">10</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">3</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
-    </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Paladin Squad" hidden="false" id="6528-4634-c2cf-2840">
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="225"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="155.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="d9f7-71b7-8e67-7f44" name="Interceptor Squad" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="set" value="450" field="51b2-306e-1021-d207">
+        <modifier type="set" field="51b2-306e-1021-d207" value="270">
           <conditions>
-            <condition type="atLeast" value="6" field="selections" scope="6528-4634-c2cf-2840" childId="model" shared="true"/>
+            <condition field="selections" scope="d9f7-71b7-8e67-7f44" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
           </conditions>
         </modifier>
       </modifiers>
-      <categoryLinks>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="cf79-bde8-5a6b-eb1a" primary="true" name="Infantry"/>
-        <categoryLink targetId="5a61-81ac-eb7c-a87e" id="448f-c140-d5cb-5e7a" primary="false" name="Grenades"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="527e-23e4-7804-2c6" primary="false" name="Imperium"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="5753-a6c6-e4c-bd32" primary="false" name="Psyker"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="ea5e-5189-d91b-221d" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="740a-892c-8958-defa" id="2139-23b3-aa8a-f1b4" primary="false" name="Terminator"/>
-        <categoryLink targetId="9020-9fb5-8ef8-5ad4" id="4243-8f2d-c516-104e" primary="false" name="Paladin Squad"/>
-      </categoryLinks>
       <profiles>
-        <profile name="Paladin Squad" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="ca57-5b17-a4ed-f420">
+        <profile id="e87d-a435-e5a2-260c" name="Interceptor Squad" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
-            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">5&quot;</characteristic>
-            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">5</characteristic>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">12&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">4</characteristic>
             <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
-            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">3</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">2</characteristic>
             <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
           </characteristics>
         </profile>
-        <profile name="Inner Fortitude (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="935d-fb65-54d-274f">
+        <profile id="8d05-c69c-2572-99ba" name="Personal Teleporters" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time an attack targets this unit, if the Strength characteristic of that attack is greater than the Toughness characteristic of this unit, subtract 1 from the Wound roll</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">In your Shooting phase, after this unit has shot, if it is not within Engagement Range of one or more enemy units, it can make a Normal move of up to 6&quot; as if it were your Movement phase. If it does, until the end of the turn, this unit is not eligible to declare a charge</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="733f-208f-7345-4c92" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Invulnerable Save (4+)" hidden="false" type="profile" id="a6ad-579-5c78-6d6a" targetId="a343-738-c273-4e13"/>
+        <infoLink id="e69a-c87-618-f1b3" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b8af-e166-8561-eb8a" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="true"/>
+        <categoryLink id="ff4c-36c3-ff9b-a087" name="Grenades" hidden="false" targetId="5a61-81ac-eb7c-a87e" primary="false"/>
+        <categoryLink id="8067-1026-3d30-9eb9" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="803c-4e4e-3025-ee93" name="Fly" hidden="false" targetId="c619-2086-bbcf-69c9" primary="false"/>
+        <categoryLink id="b691-cc17-35e9-5c92" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="333b-3d21-7808-bac1" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="2d76-f788-6240-e9bc" name="Interceptor Squad" hidden="false" targetId="b7d3-6b00-c657-ebd7" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup name="1 Paragon and 4-9 Paladins" hidden="false" id="fc49-2cb9-b72-9890" defaultSelectionEntryId="d1b3-96e2-43e6-6bf4">
+        <selectionEntryGroup id="5e2b-e394-45b-4674" name="1 Justicar and 4-9 Interceptors" hidden="false" collective="false" import="false" defaultSelectionEntryId="2906-2dfd-6dbe-ca8">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4458-9ace-aa41-4ab4" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="832a-b37e-7fa1-9eb3" type="max"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="model" import="true" name="Paragon" hidden="false" id="7eaa-bc4d-e325-6767">
+            <selectionEntry id="9ae2-cba2-3df0-81ea" name="Justicar" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2324-7215-e92a-4b1b"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e341-5b62-dcfd-8b"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2324-7215-e92a-4b1b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e341-5b62-dcfd-8b" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="1207-d408-edb8-7e91">
+                <selectionEntry id="cfe2-dc97-7f64-ee2b" name="Nemesis Force Weapon" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="5c4e-800d-8fcc-c9b0">
+                    <profile id="263d-3404-24d1-d9db" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
-                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">2+</characteristic>
+                        <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
+                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
                         <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
                         <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
                         <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
@@ -3967,16 +3771,23 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="1b41-b14-f414-bbd9" targetId="e9c4-2bb8-12ee-cd1b"/>
+                    <infoLink id="e097-4f77-7c57-4afd" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="c93f-d27c-e74f-be19">
+                <selectionEntry id="9ac9-3c48-f753-f303" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77a-f8d6-ae23-1a1d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+                  </constraints>
                   <profiles>
-                    <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="e751-4c2-214c-14cb">
+                    <profile id="389-640a-cfb-5325" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
                         <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
                         <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
                         <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
@@ -3985,32 +3796,34 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Rapid Fire" hidden="false" type="rule" id="b488-e942-7ede-3fe2" targetId="c5c8-8b58-b8b6-7786">
+                    <infoLink id="cbce-1f4c-f2f1-c18" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
                       <modifiers>
-                        <modifier type="append" value="2" field="name"/>
+                        <modifier type="append" field="name" value="2"/>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b77a-f8d6-ae23-1a1d"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Paladin" hidden="false" id="d1b3-96e2-43e6-6bf4">
+            <selectionEntry id="2906-2dfd-6dbe-ca8" name="Interceptor" hidden="false" collective="false" import="true" type="model">
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="6187-c075-7bd0-2a9b" collective="true">
+                <selectionEntry id="4e6-6d1c-3395-59d5" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="7599-4ce1-942b-4a02">
+                    <profile id="c32a-e96e-69a2-7b0e" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
-                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">2+</characteristic>
+                        <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
+                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
                         <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
                         <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
                         <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
@@ -4019,16 +3832,23 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="4d62-c396-aa37-f328" targetId="e9c4-2bb8-12ee-cd1b"/>
+                    <infoLink id="8b93-2673-9571-7a8" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="abb5-3b05-887d-41c6" collective="true">
+                <selectionEntry id="43d0-c61a-f6da-22a0" name="Storm Bolter" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77a-f8d6-ae23-1a1d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+                  </constraints>
                   <profiles>
-                    <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="e292-6ecd-c797-9f78">
+                    <profile id="2669-a603-82f5-3b05" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
-                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
                         <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
                         <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
                         <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
@@ -4037,84 +3857,47 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Rapid Fire" hidden="false" type="rule" id="5ee7-63c7-1692-43e4" targetId="c5c8-8b58-b8b6-7786">
+                    <infoLink id="962c-d4ec-34f7-f397" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
                       <modifiers>
-                        <modifier type="append" value="2" field="name"/>
+                        <modifier type="append" field="name" value="2"/>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b77a-f8d6-ae23-1a1d"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Paladin with Ancient&apos;s Banner" hidden="false" id="c782-acdd-ccd7-6cc0">
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f1a1-3c53-8f3e-5a8f" name="Heavy weapons" hidden="false" collective="false" import="false">
+              <modifiers>
+                <modifier type="set" field="2177-38f8-8e2b-c881" value="2">
+                  <conditions>
+                    <condition field="selections" scope="d9f7-71b7-8e67-7f44" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="26c3-5023-9a33-4c8"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2177-38f8-8e2b-c881" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="ee61-209f-1887-6c7a" collective="true">
+                <selectionEntry id="2711-ec49-a1b2-d789" name="Interceptor w/ incinerator" hidden="false" collective="false" import="true" type="model">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af8e-f74e-a928-8563" type="max"/>
                   </constraints>
-                  <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="bc67-b744-5e9e-a941">
-                      <characteristics>
-                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
-                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">2+</characteristic>
-                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
-                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
-                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="22f8-6e38-ab76-797f" targetId="e9c4-2bb8-12ee-cd1b"/>
-                  </infoLinks>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Ancient&apos;s Banner" hidden="false" id="9812-9e40-480b-5b78" collective="true">
-                  <profiles>
-                    <profile name="Ancient&apos;s Banner" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="b14b-6903-19ca-ea38">
-                      <characteristics>
-                        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Add 1 to the Objective Control characteristic of models in the bearer’s unit.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7ced-59bb-1646-d784"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1060-a780-b862-b87b"/>
-                  </constraints>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup name="Weapon Choice" hidden="false" id="f8cc-ac46-67b2-46f6" defaultSelectionEntryId="1202-d63-2028-ab5c">
                   <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Psycannon" hidden="false" id="d970-7af-8ceb-f662">
-                      <infoLinks>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="69e1-eb07-bec0-1f7d" targetId="e9c4-2bb8-12ee-cd1b"/>
-                      </infoLinks>
+                    <selectionEntry id="3c17-244d-6ddd-3062" name="Incinerator" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e37-b7a8-d90f-e3f9" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="221a-c1e5-34b4-1ff9" type="max"/>
+                      </constraints>
                       <profiles>
-                        <profile name="Psycannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="cabc-5b1c-217f-1d67">
-                          <characteristics>
-                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                            <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
-                            <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Incinerator" hidden="false" id="e308-5d95-ccfe-a490">
-                      <profiles>
-                        <profile name="Incinerator" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="23d7-b9aa-b373-86a8">
+                        <profile id="d504-4243-e8b0-417" name="Incinerator" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
@@ -4127,13 +3910,698 @@
                         </profile>
                       </profiles>
                       <infoLinks>
-                        <infoLink name="Ignores Cover" hidden="false" type="rule" id="9cdd-d607-55a9-bc6f" targetId="4640-43e7-30b-215a"/>
-                        <infoLink name="Torrent" hidden="false" type="rule" id="25af-e18b-3623-51f9" targetId="5edf-d619-23e0-9b56"/>
+                        <infoLink id="5350-f1ef-ee60-7029" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+                        <infoLink id="ad14-b2a1-216c-9b4d" name="Torrent" hidden="false" targetId="5edf-d619-23e0-9b56" type="rule"/>
                       </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Psilencer" hidden="false" id="548f-f4dd-7e32-9d31">
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="352f-9507-f9e3-9c7b" name="Close combat weapon" hidden="false" collective="false" import="true" targetId="d0e-7460-ee7b-660f" type="selectionEntry"/>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="dbfa-42d3-8ac9-c4dc" name="Interceptor w/ psilencer" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af8e-f74e-a928-8563" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="31f3-fb44-bc7d-8a12" name="Psilencer" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="985a-b83-56e0-a974" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4aa-3271-e6c8-3277" type="max"/>
+                      </constraints>
                       <profiles>
-                        <profile name="Psilencer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="8750-4404-1827-a41d">
+                        <profile id="5da7-4bd0-5f3e-d9e4" name="Psilencer" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                          <characteristics>
+                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                            <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
+                            <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic, Sustained Hits 1</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <infoLinks>
+                        <infoLink id="b6a6-11be-9917-a9d" name="Sustained Hits" hidden="false" targetId="1897-c22c-9597-12b1" type="rule">
+                          <modifiers>
+                            <modifier type="append" field="name" value="1"/>
+                          </modifiers>
+                        </infoLink>
+                        <infoLink id="73d1-1d3c-9ad1-90e4" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="83fe-fab0-7644-838" name="Close combat weapon" hidden="false" collective="false" import="true" targetId="d0e-7460-ee7b-660f" type="selectionEntry"/>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="ad0c-76b3-3c42-4aff" name="Interceptor w/ psycannon" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af8e-f74e-a928-8563" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="cfe5-513-b46e-9e50" name="Psycannon" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c2e-72b3-9253-88ab" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f0d-e773-3252-c7dd" type="max"/>
+                      </constraints>
+                      <profiles>
+                        <profile id="1dbb-6f8c-d9e7-2da2" name="Psycannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                          <characteristics>
+                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                            <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
+                            <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <infoLinks>
+                        <infoLink id="d2fb-2ea8-7a7-9a4" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="d5f4-74d5-5b7a-58ae" name="Close combat weapon" hidden="false" collective="false" import="true" targetId="d0e-7460-ee7b-660f" type="selectionEntry"/>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="135.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7a19-5235-692b-320d" name="Kaldor Draigo" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="6a1b-3b7e-67b5-c5ec" name="Kaldor Draigo" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">5&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">5</characteristic>
+            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">7</characteristic>
+            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
+            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cf12-2ea5-6834-5031" name="Untouchable Purity" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model is leading a unit, models in that unit have the Feel No Pain 4+ ability against mortal wounds</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c3e8-c9b9-519a-6552" name="One With the Warp (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Once per battle, when this model’s unit declares a charge in the same turn it was set up as Reinforcements using the Deep Strike ability, add 3 to the Charge roll.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d668-10b1-f5d9-9bd0" name="Leader" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
+■ Brotherhood Terminator Squad
+■ Paladin Squad</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="64e5-ddc6-93b6-845d" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="413b-33bd-e69-59ba" name="Leader" hidden="false" targetId="b4dd-3e1f-41cb-218f" type="rule"/>
+        <infoLink id="acfb-af78-3ddc-69f7" name="Invulnerable Save (4+)" hidden="false" targetId="df6-e949-835b-ad0d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9a47-1367-b3dd-1318" name="Epic Hero" hidden="false" targetId="4f3a-f0f7-6647-348d" primary="true"/>
+        <categoryLink id="6d61-f3b8-b904-a4b1" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="false"/>
+        <categoryLink id="38e8-3e1f-cc4b-c599" name="Character" hidden="false" targetId="9cfd-1c32-585f-7d5c" primary="false"/>
+        <categoryLink id="4a70-5ece-cdce-924a" name="Grenades" hidden="false" targetId="5a61-81ac-eb7c-a87e" primary="false"/>
+        <categoryLink id="715b-8435-9a7f-e014" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="d4c0-6968-e9d3-8f8d" name="Terminator" hidden="false" targetId="740a-892c-8958-defa" primary="false"/>
+        <categoryLink id="6ac8-3336-cc7c-520d" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="b36b-5551-4933-6a09" name="Kaldor Draigo" hidden="false" targetId="77b6-bfe8-648b-9fb4" primary="false"/>
+        <categoryLink id="873-2d09-87d5-f51b" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1934-6940-4a56-4ac3" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11a3-8954-73c5-f558" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="c564-12d6-1b9d-5e06" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="24a0-3ca0-de94-f9e9" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value="2"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8804-9b5d-14e7-5e2d" name="Scourging" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6338-b970-2315-d2a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d220-9471-922f-f613" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2874-4a20-ee8c-ed97" name="Scourging" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
+                <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
+                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Anti-Daemon 2+, Ignores Cover, Psychic</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b9fb-d4e1-34ae-d02f" name="The Titansword" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="752f-dcfd-a273-b1f4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2015-9370-77a-aeb1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="232a-4043-3ee0-f92" name="The Titansword" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+              <characteristics>
+                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
+                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">2+</characteristic>
+                <characteristic name="S" typeId="ab33-d393-96ce-ccba">8</characteristic>
+                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-4</characteristic>
+                <characteristic name="D" typeId="3254-9fe6-d824-513e">3</characteristic>
+                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Anti-Daemon 2+, Psychic</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="11ba-e4a9-aa6-2721" name="Warlord" hidden="false" collective="false" import="true" targetId="beae-4593-3686-1672" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="125.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5458-a458-c51d-c4e9" name="Nemesis Dreadknight" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="a1ef-3a29-210b-de07" name="Nemesis Dreadknight" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">8&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">8</characteristic>
+            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">13</characteristic>
+            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
+            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c53f-7fdc-438d-5dcd" name="Empyric Reprisal (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model is eligible to shoot and declare a charge in a turn in which it Advanced or Fell Back.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6980-2489-73f9-24ed" name="Damaged: 1-4 Wounds Remaining" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-4 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f7cf-34d4-c47-b12b" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="zz44-ab36-7h9l-2b6j" name="Deadly Demise" hidden="false" targetId="b68a-5ded-65ac-98c" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="D3"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9c1d-310d-3e87-e513" name="Invulnerable Save (4+)" hidden="false" targetId="df6-e949-835b-ad0d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="87ef-bf19-85f0-d3fe" name="Nemesis Dreadknight" hidden="false" targetId="8083-7b7a-c9d7-fd31" primary="false"/>
+        <categoryLink id="5ab4-220c-a69b-9f99" name="Vehicle" hidden="false" targetId="dbd4-63-af05-998" primary="true"/>
+        <categoryLink id="51dd-535c-7f1b-c027" name="Walker" hidden="false" targetId="6dda-e157-334d-e93a" primary="false"/>
+        <categoryLink id="6fcb-25d8-c666-ac6f" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="46db-601-55fc-84d0" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e21a-cac0-9dfe-5ee2" name="Melee Weapon" hidden="false" collective="false" import="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a82-2089-499b-22f5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a52-d62d-bc42-4638" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9f7f-ad95-cb89-3df6" name="Dreadfists" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="47a-1263-759-50b7" name="Dreadfists" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                    <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
+                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
+                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-1</characteristic>
+                    <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c87c-a41d-9640-aa1e" name="Nemesis Greatsword" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="72e7-ba02-c736-caf7" name="➤ Nemesis Greatsword - Strike" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
+                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">10</characteristic>
+                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
+                    <characteristic name="D" typeId="3254-9fe6-d824-513e">D6</characteristic>
+                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="5047-d408-9c6d-9b63" name="➤ Nemesis Greatsword - Sweep" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                    <characteristic name="A" typeId="2337-daa1-6682-b110">10</characteristic>
+                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">5</characteristic>
+                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-1</characteristic>
+                    <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6fe6-97cc-6f34-b23e" name="Nemesis Daemon Greathammer" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="967e-5402-f748-5ec4" name="Nemesis Daemon Greathammer" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                    <characteristic name="A" typeId="2337-daa1-6682-b110">5</characteristic>
+                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
+                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">14</characteristic>
+                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-3</characteristic>
+                    <characteristic name="D" typeId="3254-9fe6-d824-513e">D6+1</characteristic>
+                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="88f7-cb71-5700-82da" name="Ranged Weapons" hidden="false" collective="false" import="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc9b-65d8-6819-f049" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="eea8-d667-691b-336c" name="Gatling Psilencer" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="726a-32bc-86bf-3e4d" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="61d-b7d7-761c-739b" name="Gatling Psilencer" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">12</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic, Sustained Hits 1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5e54-2e6d-48a1-5b6e" name="Heavy Incinerator" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abc4-70df-6525-ab6a" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="2de9-9b67-647a-e973" name="Heavy Incinerator" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">2D6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Torrent</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d93e-2aa1-5f95-72a8" name="Heavy Psycannon" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d66-7435-917a-74fd" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="e63a-efa4-e920-d2a0" name="Heavy Psycannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">10</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">3</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="185.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6528-4634-c2cf-2840" name="Paladin Squad" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="51b2-306e-1021-d207" value="450">
+          <conditions>
+            <condition field="selections" scope="6528-4634-c2cf-2840" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="ca57-5b17-a4ed-f420" name="Paladin Squad" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">5&quot;</characteristic>
+            <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">5</characteristic>
+            <characteristic name="SV" typeId="450-a17e-9d5e-29da">2+</characteristic>
+            <characteristic name="W" typeId="750a-a2ec-90d3-21fe">3</characteristic>
+            <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
+            <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="935d-fb65-54d-274f" name="Inner Fortitude (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time an attack targets this unit, if the Strength characteristic of that attack is greater than the Toughness characteristic of this unit, subtract 1 from the Wound roll</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="733f-208f-7345-4c92" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="a6ad-579-5c78-6d6a" name="Invulnerable Save (4+)" hidden="false" targetId="a343-738-c273-4e13" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="cf79-bde8-5a6b-eb1a" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="true"/>
+        <categoryLink id="448f-c140-d5cb-5e7a" name="Grenades" hidden="false" targetId="5a61-81ac-eb7c-a87e" primary="false"/>
+        <categoryLink id="527e-23e4-7804-2c6" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="5753-a6c6-e4c-bd32" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="ea5e-5189-d91b-221d" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="2139-23b3-aa8a-f1b4" name="Terminator" hidden="false" targetId="740a-892c-8958-defa" primary="false"/>
+        <categoryLink id="4243-8f2d-c516-104e" name="Paladin Squad" hidden="false" targetId="9020-9fb5-8ef8-5ad4" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fc49-2cb9-b72-9890" name="1 Paragon and 4-9 Paladins" hidden="false" collective="false" import="false" defaultSelectionEntryId="d1b3-96e2-43e6-6bf4">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e99f-6e07-1a6b-a4a4" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3fa-db46-4723-6423" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7eaa-bc4d-e325-6767" name="Paragon" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2324-7215-e92a-4b1b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e341-5b62-dcfd-8b" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="1207-d408-edb8-7e91" name="Nemesis Force Weapon" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="5c4e-800d-8fcc-c9b0" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                      <characteristics>
+                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
+                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">2+</characteristic>
+                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
+                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
+                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
+                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="1b41-b14-f414-bbd9" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="c93f-d27c-e74f-be19" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77a-f8d6-ae23-1a1d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="e751-4c2-214c-14cb" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                      <characteristics>
+                        <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                        <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                        <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                        <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                        <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="b488-e942-7ede-3fe2" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
+                      <modifiers>
+                        <modifier type="append" field="name" value="2"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d1b3-96e2-43e6-6bf4" name="Paladin" hidden="false" collective="false" import="true" type="model">
+              <selectionEntries>
+                <selectionEntry id="6187-c075-7bd0-2a9b" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="7599-4ce1-942b-4a02" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                      <characteristics>
+                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
+                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">2+</characteristic>
+                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
+                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
+                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
+                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="4d62-c396-aa37-f328" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="abb5-3b05-887d-41c6" name="Storm Bolter" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77a-f8d6-ae23-1a1d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="e292-6ecd-c797-9f78" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                      <characteristics>
+                        <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                        <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                        <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                        <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                        <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Rapid Fire 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="5ee7-63c7-1692-43e4" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
+                      <modifiers>
+                        <modifier type="append" field="name" value="2"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c782-acdd-ccd7-6cc0" name="Paladin with Ancient&apos;s Banner" hidden="false" collective="false" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26c3-5023-9a33-4c8" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="ee61-209f-1887-6c7a" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="bc67-b744-5e9e-a941" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
+                      <characteristics>
+                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                        <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
+                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">2+</characteristic>
+                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
+                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
+                        <characteristic name="D" typeId="3254-9fe6-d824-513e">2</characteristic>
+                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="22f8-6e38-ab76-797f" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="9812-9e40-480b-5b78" name="Ancient&apos;s Banner" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ced-59bb-1646-d784" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1060-a780-b862-b87b" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="b14b-6903-19ca-ea38" name="Ancient&apos;s Banner" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+                      <characteristics>
+                        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Add 1 to the Objective Control characteristic of models in the bearer’s unit.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="f8cc-ac46-67b2-46f6" name="Weapon Choice" hidden="false" collective="false" import="false" defaultSelectionEntryId="1202-d63-2028-ab5c">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91fc-5d4d-70a1-955f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b66e-ec0f-231-9d5f" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="d970-7af-8ceb-f662" name="Psycannon" hidden="false" collective="false" import="true" type="upgrade">
+                      <profiles>
+                        <profile id="cabc-5b1c-217f-1d67" name="Psycannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                          <characteristics>
+                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                            <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
+                            <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <infoLinks>
+                        <infoLink id="69e1-eb07-bec0-1f7d" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="e308-5d95-ccfe-a490" name="Incinerator" hidden="false" collective="false" import="true" type="upgrade">
+                      <profiles>
+                        <profile id="23d7-b9aa-b373-86a8" name="Incinerator" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                          <characteristics>
+                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
+                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
+                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
+                            <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                            <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Torrent</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <infoLinks>
+                        <infoLink id="9cdd-d607-55a9-bc6f" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+                        <infoLink id="25af-e18b-3623-51f9" name="Torrent" hidden="false" targetId="5edf-d619-23e0-9b56" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="548f-f4dd-7e32-9d31" name="Psilencer" hidden="false" collective="false" import="true" type="upgrade">
+                      <profiles>
+                        <profile id="8750-4404-1827-a41d" name="Psilencer" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
@@ -4146,17 +4614,23 @@
                         </profile>
                       </profiles>
                       <infoLinks>
-                        <infoLink name="Sustained Hits" hidden="false" type="rule" id="3dda-8316-3011-ffbb" targetId="1897-c22c-9597-12b1">
+                        <infoLink id="3dda-8316-3011-ffbb" name="Sustained Hits" hidden="false" targetId="1897-c22c-9597-12b1" type="rule">
                           <modifiers>
-                            <modifier type="append" value="1" field="name"/>
+                            <modifier type="append" field="name" value="1"/>
                           </modifiers>
                         </infoLink>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="2387-5bb2-eb96-73af" targetId="e9c4-2bb8-12ee-cd1b"/>
+                        <infoLink id="2387-5bb2-eb96-73af" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
                       </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="1202-d63-2028-ab5c">
+                    <selectionEntry id="1202-d63-2028-ab5c" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+                      </constraints>
                       <profiles>
-                        <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="d936-c90b-941d-e6d8">
+                        <profile id="d936-c90b-941d-e6d8" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -4169,113 +4643,42 @@
                         </profile>
                       </profiles>
                       <infoLinks>
-                        <infoLink name="Rapid Fire" hidden="false" type="rule" id="9d14-9791-f609-797e" targetId="c5c8-8b58-b8b6-7786">
+                        <infoLink id="9d14-9791-f609-797e" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
                           <modifiers>
-                            <modifier type="append" value="2" field="name"/>
+                            <modifier type="append" field="name" value="2"/>
                           </modifiers>
                         </infoLink>
                       </infoLinks>
-                      <constraints>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="91fc-5d4d-70a1-955f"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b66e-ec0f-231-9d5f"/>
-                  </constraints>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Paladin with Heavy Weapon" hidden="false" id="7f57-9a5a-c5bf-851a">
-              <selectionEntryGroups>
-                <selectionEntryGroup name="Weapon Choice" hidden="false" id="a890-27d0-cd5-b20" defaultSelectionEntryId="e1fa-34a1-5580-b7c8">
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Psycannon" hidden="false" id="e1fa-34a1-5580-b7c8">
-                      <infoLinks>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="f07e-72c1-76ec-d5d4" targetId="e9c4-2bb8-12ee-cd1b"/>
-                      </infoLinks>
-                      <profiles>
-                        <profile name="Psycannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="e111-2d02-96ea-d14f">
-                          <characteristics>
-                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
-                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                            <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
-                            <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Incinerator" hidden="false" id="5c0-5677-cffb-374c">
-                      <profiles>
-                        <profile name="Incinerator" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="4595-6050-402a-12e3">
-                          <characteristics>
-                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
-                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
-                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
-                            <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                            <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Torrent</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <infoLinks>
-                        <infoLink name="Ignores Cover" hidden="false" type="rule" id="a7cb-5a53-1b98-8ea5" targetId="4640-43e7-30b-215a"/>
-                        <infoLink name="Torrent" hidden="false" type="rule" id="63b3-2e2f-4608-4aa1" targetId="5edf-d619-23e0-9b56"/>
-                      </infoLinks>
-                    </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Psilencer" hidden="false" id="f2a4-ccdb-517c-9e67">
-                      <profiles>
-                        <profile name="Psilencer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="5748-3cdc-9b93-b1a8">
-                          <characteristics>
-                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
-                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
-                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
-                            <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
-                            <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic, Sustained Hits 1</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <infoLinks>
-                        <infoLink name="Sustained Hits" hidden="false" type="rule" id="6c1-2672-56af-718a" targetId="1897-c22c-9597-12b1">
-                          <modifiers>
-                            <modifier type="append" value="1" field="name"/>
-                          </modifiers>
-                        </infoLink>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="26c5-677d-efa8-edbe" targetId="e9c4-2bb8-12ee-cd1b"/>
-                      </infoLinks>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="91fc-5d4d-70a1-955f"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b66e-ec0f-231-9d5f"/>
-                  </constraints>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <constraints>
-                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="702-d447-314b-a3f6"/>
-              </constraints>
+            <selectionEntry id="7f57-9a5a-c5bf-851a" name="Paladin with Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
-                <modifier type="set" value="4" field="702-d447-314b-a3f6">
+                <modifier type="set" field="702-d447-314b-a3f6" value="4">
                   <conditions>
-                    <condition type="atLeast" value="10" field="selections" scope="6528-4634-c2cf-2840" childId="model" shared="true"/>
+                    <condition field="selections" scope="6528-4634-c2cf-2840" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
                   </conditions>
                 </modifier>
               </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="702-d447-314b-a3f6" type="max"/>
+              </constraints>
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="81c3-5e9-d8b1-63c7" collective="true">
+                <selectionEntry id="81c3-5e9-d8b1-63c7" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="5ca4-43c1-f41-9352">
+                    <profile id="5ca4-43c1-f41-9352" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                         <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
@@ -4288,40 +4691,113 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="f9da-e420-1163-d0a6" targetId="e9c4-2bb8-12ee-cd1b"/>
+                    <infoLink id="f9da-e420-1163-d0a6" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="a890-27d0-cd5-b20" name="Weapon Choice" hidden="false" collective="false" import="false" defaultSelectionEntryId="e1fa-34a1-5580-b7c8">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91fc-5d4d-70a1-955f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b66e-ec0f-231-9d5f" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="e1fa-34a1-5580-b7c8" name="Psycannon" hidden="false" collective="false" import="true" type="upgrade">
+                      <profiles>
+                        <profile id="e111-2d02-96ea-d14f" name="Psycannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                          <characteristics>
+                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
+                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                            <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
+                            <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <infoLinks>
+                        <infoLink id="f07e-72c1-76ec-d5d4" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="5c0-5677-cffb-374c" name="Incinerator" hidden="false" collective="false" import="true" type="upgrade">
+                      <profiles>
+                        <profile id="4595-6050-402a-12e3" name="Incinerator" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                          <characteristics>
+                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
+                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
+                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
+                            <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+                            <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Torrent</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <infoLinks>
+                        <infoLink id="a7cb-5a53-1b98-8ea5" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+                        <infoLink id="63b3-2e2f-4608-4aa1" name="Torrent" hidden="false" targetId="5edf-d619-23e0-9b56" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="f2a4-ccdb-517c-9e67" name="Psilencer" hidden="false" collective="false" import="true" type="upgrade">
+                      <profiles>
+                        <profile id="5748-3cdc-9b93-b1a8" name="Psilencer" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                          <characteristics>
+                            <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                            <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
+                            <characteristic name="BS" typeId="94d-8a98-cf90-183e">2+</characteristic>
+                            <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
+                            <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+                            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+                            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Psychic, Sustained Hits 1</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <infoLinks>
+                        <infoLink id="6c1-2672-56af-718a" name="Sustained Hits" hidden="false" targetId="1897-c22c-9597-12b1" type="rule">
+                          <modifiers>
+                            <modifier type="append" field="name" value="1"/>
+                          </modifiers>
+                        </infoLink>
+                        <infoLink id="26c5-677d-efa8-edbe" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="5" field="selections" scope="parent" shared="true" id="e99f-6e07-1a6b-a4a4"/>
-            <constraint type="max" value="10" field="selections" scope="parent" shared="true" id="e3fa-db46-4723-6423"/>
-          </constraints>
         </selectionEntryGroup>
       </selectionEntryGroups>
-    </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Purgation Squad" hidden="false" id="e8ad-bd40-5952-6859">
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="135"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="225.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="e8ad-bd40-5952-6859" name="Purgation Squad" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="set" value="270" field="51b2-306e-1021-d207">
+        <modifier type="set" field="51b2-306e-1021-d207" value="270">
           <conditions>
-            <condition type="atLeast" value="6" field="selections" scope="e8ad-bd40-5952-6859" childId="model" shared="true"/>
+            <condition field="selections" scope="e8ad-bd40-5952-6859" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
           </conditions>
         </modifier>
       </modifiers>
-      <categoryLinks>
-        <categoryLink targetId="8084-5bdd-7c6-bae4" id="567-956f-41fe-8488" primary="false" name="Purgation Squad"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="ea0f-c8a4-e26d-9d03" primary="false" name="Psyker"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="e193-9deb-6e79-cd7" primary="false" name="Imperium"/>
-        <categoryLink targetId="5a61-81ac-eb7c-a87e" id="6569-1234-4145-2c8c" primary="false" name="Grenades"/>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="6a37-9c32-ae20-14ff" primary="true" name="Infantry"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="11ba-baeb-e570-ccea" primary="false" name="Faction: Grey Knights"/>
-      </categoryLinks>
       <profiles>
-        <profile name="Purgation Squad" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="e6e3-290b-6bef-ddd7">
+        <profile id="e6e3-290b-6bef-ddd7" name="Purgation Squad" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">6&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">4</characteristic>
@@ -4331,31 +4807,43 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
           </characteristics>
         </profile>
-        <profile name="Astral Aim (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="6515-217f-6031-85ce">
+        <profile id="6515-217f-6031-85ce" name="Astral Aim (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">In your Shooting phase, ranged weapons equipped by models in this unit have the [INDIRECT FIRE] ability, provided the target of that weapon is visible to one or more other friendly Grey Knights Psyker units</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="ccdc-7e6-7559-e0f0" targetId="7cb5-dd6b-dd87-ad3b"/>
+        <infoLink id="ccdc-7e6-7559-e0f0" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="567-956f-41fe-8488" name="Purgation Squad" hidden="false" targetId="8084-5bdd-7c6-bae4" primary="false"/>
+        <categoryLink id="ea0f-c8a4-e26d-9d03" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="e193-9deb-6e79-cd7" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="6569-1234-4145-2c8c" name="Grenades" hidden="false" targetId="5a61-81ac-eb7c-a87e" primary="false"/>
+        <categoryLink id="6a37-9c32-ae20-14ff" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="true"/>
+        <categoryLink id="11ba-baeb-e570-ccea" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup name="1 Justicar and 4-9 Purgators" hidden="false" id="8b45-3ad-69a7-ac55" defaultSelectionEntryId="ee3b-2ec2-2841-7e66">
+        <selectionEntryGroup id="8b45-3ad-69a7-ac55" name="1 Justicar and 4-9 Purgators" hidden="false" collective="false" import="false" defaultSelectionEntryId="ee3b-2ec2-2841-7e66">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4458-9ace-aa41-4ab4" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="832a-b37e-7fa1-9eb3" type="max"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="model" import="true" name="Justicar" hidden="false" id="5f9-7ef3-ba5b-6352">
+            <selectionEntry id="5f9-7ef3-ba5b-6352" name="Justicar" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2324-7215-e92a-4b1b"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e341-5b62-dcfd-8b"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2324-7215-e92a-4b1b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e341-5b62-dcfd-8b" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="e23c-c956-54ae-96bf">
+                <selectionEntry id="e23c-c956-54ae-96bf" name="Nemesis Force Weapon" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="1481-3c76-257b-73d2">
+                    <profile id="1481-3c76-257b-73d2" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                         <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
@@ -4368,12 +4856,19 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="1b32-df22-859-ec62" targetId="e9c4-2bb8-12ee-cd1b"/>
+                    <infoLink id="1b32-df22-859-ec62" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="d791-32c3-c5ec-29e0">
+                <selectionEntry id="d791-32c3-c5ec-29e0" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77a-f8d6-ae23-1a1d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+                  </constraints>
                   <profiles>
-                    <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="262c-db68-294b-c279">
+                    <profile id="262c-db68-294b-c279" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -4386,28 +4881,30 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Rapid Fire" hidden="false" type="rule" id="5c75-9bd2-11aa-3957" targetId="c5c8-8b58-b8b6-7786">
+                    <infoLink id="5c75-9bd2-11aa-3957" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
                       <modifiers>
-                        <modifier type="append" value="2" field="name"/>
+                        <modifier type="append" field="name" value="2"/>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b77a-f8d6-ae23-1a1d"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Purgator" hidden="false" id="ee3b-2ec2-2841-7e66">
+            <selectionEntry id="ee3b-2ec2-2841-7e66" name="Purgator" hidden="false" collective="false" import="true" type="model">
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="3f2f-f59d-6aba-cf85" collective="true">
+                <selectionEntry id="3f2f-f59d-6aba-cf85" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="84cc-c727-e4f5-b304">
+                    <profile id="84cc-c727-e4f5-b304" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                         <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
@@ -4420,12 +4917,19 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="fd2a-8d8-632-af51" targetId="e9c4-2bb8-12ee-cd1b"/>
+                    <infoLink id="fd2a-8d8-632-af51" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="b398-1281-6d4e-2eed" collective="true">
+                <selectionEntry id="b398-1281-6d4e-2eed" name="Storm Bolter" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77a-f8d6-ae23-1a1d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+                  </constraints>
                   <profiles>
-                    <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="5964-f29-6c46-a3eb">
+                    <profile id="5964-f29-6c46-a3eb" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -4438,35 +4942,40 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Rapid Fire" hidden="false" type="rule" id="5b43-4239-3dff-666c" targetId="c5c8-8b58-b8b6-7786">
+                    <infoLink id="5b43-4239-3dff-666c" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
                       <modifiers>
-                        <modifier type="append" value="2" field="name"/>
+                        <modifier type="append" field="name" value="2"/>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b77a-f8d6-ae23-1a1d"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="5" field="selections" scope="parent" shared="true" id="4458-9ace-aa41-4ab4"/>
-            <constraint type="max" value="10" field="selections" scope="parent" shared="true" id="832a-b37e-7fa1-9eb3"/>
-          </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup name="Heavy Weapons" hidden="false" id="fb6c-362f-95ea-80a8">
+            <selectionEntryGroup id="fb6c-362f-95ea-80a8" name="Heavy Weapons" hidden="false" collective="false" import="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="343a-2add-59f1-7f93" type="max"/>
+              </constraints>
               <selectionEntries>
-                <selectionEntry type="model" import="true" name="Purgator w/ incinerator" hidden="false" id="74a8-a54f-98b9-4d09">
+                <selectionEntry id="74a8-a54f-98b9-4d09" name="Purgator w/ incinerator" hidden="false" collective="false" import="true" type="model">
                   <constraints>
-                    <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="ccf4-ba2b-2bd4-abb"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccf4-ba2b-2bd4-abb" type="max"/>
                   </constraints>
                   <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Incinerator" hidden="false" id="c71f-f97a-a5f-313a" collective="true">
+                    <selectionEntry id="c71f-f97a-a5f-313a" name="Incinerator" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f315-1bb1-18cf-3e47" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1347-1035-836c-fcf2" type="max"/>
+                      </constraints>
                       <profiles>
-                        <profile name="Incinerator" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="1791-6602-adc4-bb2b">
+                        <profile id="1791-6602-adc4-bb2b" name="Incinerator" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
@@ -4479,27 +4988,33 @@
                         </profile>
                       </profiles>
                       <infoLinks>
-                        <infoLink name="Ignores Cover" hidden="false" type="rule" id="ce0a-862d-8ccd-d59c" targetId="4640-43e7-30b-215a"/>
-                        <infoLink name="Torrent" hidden="false" type="rule" id="c350-e4ab-69a3-bb24" targetId="5edf-d619-23e0-9b56"/>
+                        <infoLink id="ce0a-862d-8ccd-d59c" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+                        <infoLink id="c350-e4ab-69a3-bb24" name="Torrent" hidden="false" targetId="5edf-d619-23e0-9b56" type="rule"/>
                       </infoLinks>
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f315-1bb1-18cf-3e47"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1347-1035-836c-fcf2"/>
-                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
-                    <entryLink import="true" name="Close combat weapon" hidden="false" type="selectionEntry" id="769f-d30f-9caa-2f4c" targetId="d0e-7460-ee7b-660f"/>
+                    <entryLink id="769f-d30f-9caa-2f4c" name="Close combat weapon" hidden="false" collective="false" import="true" targetId="d0e-7460-ee7b-660f" type="selectionEntry"/>
                   </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="model" import="true" name="Purgator w/ psilencer" hidden="false" id="ce96-29f0-f79e-907d">
+                <selectionEntry id="ce96-29f0-f79e-907d" name="Purgator w/ psilencer" hidden="false" collective="false" import="true" type="model">
                   <constraints>
-                    <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="ccf4-ba2b-2bd4-abb"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccf4-ba2b-2bd4-abb" type="max"/>
                   </constraints>
                   <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Psilencer" hidden="false" id="367c-89e9-771a-99e6" collective="true">
+                    <selectionEntry id="367c-89e9-771a-99e6" name="Psilencer" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aac-f076-2a93-6273" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25a3-31bb-a777-a582" type="max"/>
+                      </constraints>
                       <profiles>
-                        <profile name="Psilencer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="49f9-6c81-3193-a1d3">
+                        <profile id="49f9-6c81-3193-a1d3" name="Psilencer" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
@@ -4512,34 +5027,37 @@
                         </profile>
                       </profiles>
                       <infoLinks>
-                        <infoLink name="Sustained Hits" hidden="false" type="rule" id="7422-314e-bd96-af6c" targetId="1897-c22c-9597-12b1">
+                        <infoLink id="7422-314e-bd96-af6c" name="Sustained Hits" hidden="false" targetId="1897-c22c-9597-12b1" type="rule">
                           <modifiers>
-                            <modifier type="append" value="1" field="name"/>
+                            <modifier type="append" field="name" value="1"/>
                           </modifiers>
                         </infoLink>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="9d80-8561-e791-465f" targetId="e9c4-2bb8-12ee-cd1b"/>
+                        <infoLink id="9d80-8561-e791-465f" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
                       </infoLinks>
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6aac-f076-2a93-6273"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="25a3-31bb-a777-a582"/>
-                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
-                    <entryLink import="true" name="Close combat weapon" hidden="false" type="selectionEntry" id="591a-6fd0-ec4a-da18" targetId="d0e-7460-ee7b-660f"/>
+                    <entryLink id="591a-6fd0-ec4a-da18" name="Close combat weapon" hidden="false" collective="false" import="true" targetId="d0e-7460-ee7b-660f" type="selectionEntry"/>
                   </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="model" import="true" name="Purgator w/ psycannon" hidden="false" id="f0ad-a5ac-154b-e21d">
+                <selectionEntry id="f0ad-a5ac-154b-e21d" name="Purgator w/ psycannon" hidden="false" collective="false" import="true" type="model">
                   <constraints>
-                    <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="ccf4-ba2b-2bd4-abb"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccf4-ba2b-2bd4-abb" type="max"/>
                   </constraints>
                   <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Psycannon" hidden="false" id="eb06-2a1b-48c0-c353" collective="true">
-                      <infoLinks>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="e33c-2223-f8c7-65e6" targetId="e9c4-2bb8-12ee-cd1b"/>
-                      </infoLinks>
+                    <selectionEntry id="eb06-2a1b-48c0-c353" name="Psycannon" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85a0-590d-bbbb-8574" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea61-1571-2465-1a32" type="max"/>
+                      </constraints>
                       <profiles>
-                        <profile name="Psycannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="4eae-a6a9-5ab4-2b40">
+                        <profile id="4eae-a6a9-5ab4-2b40" name="Psycannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
@@ -4551,46 +5069,40 @@
                           </characteristics>
                         </profile>
                       </profiles>
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="85a0-590d-bbbb-8574"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ea61-1571-2465-1a32"/>
-                      </constraints>
+                      <infoLinks>
+                        <infoLink id="e33c-2223-f8c7-65e6" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
-                    <entryLink import="true" name="Close combat weapon" hidden="false" type="selectionEntry" id="18a0-c70f-d6ca-976c" targetId="d0e-7460-ee7b-660f"/>
+                    <entryLink id="18a0-c70f-d6ca-976c" name="Close combat weapon" hidden="false" collective="false" import="true" targetId="d0e-7460-ee7b-660f" type="selectionEntry"/>
                   </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
-              <constraints>
-                <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="343a-2add-59f1-7f93"/>
-              </constraints>
             </selectionEntryGroup>
           </selectionEntryGroups>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="135.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Purifier Squad" hidden="false" id="8865-df22-1629-bf02">
+    <selectionEntry id="8865-df22-1629-bf02" name="Purifier Squad" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="set" value="260" field="51b2-306e-1021-d207">
+        <modifier type="set" field="51b2-306e-1021-d207" value="260">
           <conditions>
-            <condition type="atLeast" value="6" field="selections" scope="8865-df22-1629-bf02" childId="model" shared="true"/>
+            <condition field="selections" scope="8865-df22-1629-bf02" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
           </conditions>
         </modifier>
       </modifiers>
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="130"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="67f8-444-b8b7-ad0" id="3ed3-e5a7-87aa-fa35" primary="false" name="Purifier Squad"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="4209-c7f5-bde-74e0" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="e19c-2fef-8843-17a5" primary="false" name="Psyker"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="474a-9505-f094-5ec0" primary="false" name="Imperium"/>
-        <categoryLink targetId="5a61-81ac-eb7c-a87e" id="c6a9-46db-814f-2915" primary="false" name="Grenades"/>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="a3b9-b773-4cf3-e214" primary="true" name="Infantry"/>
-      </categoryLinks>
       <profiles>
-        <profile name="Purifier Squad" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="1ca-2f4a-980e-a0ad">
+        <profile id="1ca-2f4a-980e-a0ad" name="Purifier Squad" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">6&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">4</characteristic>
@@ -4600,31 +5112,43 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
           </characteristics>
         </profile>
-        <profile name="Sanctity of Purpose" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="f2c4-c894-81d4-d126">
+        <profile id="f2c4-c894-81d4-d126" name="Sanctity of Purpose" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a model in this unit makes an attack, add 1 to the Hit roll if this unit is below its Starting Strength, and add 1 to the Wound roll as well if this unit is Below Half-strength.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="6e98-731d-58d-389" targetId="7cb5-dd6b-dd87-ad3b"/>
+        <infoLink id="6e98-731d-58d-389" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3ed3-e5a7-87aa-fa35" name="Purifier Squad" hidden="false" targetId="67f8-444-b8b7-ad0" primary="false"/>
+        <categoryLink id="4209-c7f5-bde-74e0" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="e19c-2fef-8843-17a5" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="474a-9505-f094-5ec0" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="c6a9-46db-814f-2915" name="Grenades" hidden="false" targetId="5a61-81ac-eb7c-a87e" primary="false"/>
+        <categoryLink id="a3b9-b773-4cf3-e214" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="true"/>
+      </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup name="1 Knight of the Flame and 4-9 Purifiers" hidden="false" id="868b-4c64-84da-f47c" defaultSelectionEntryId="2105-9372-a043-df0c">
+        <selectionEntryGroup id="868b-4c64-84da-f47c" name="1 Knight of the Flame and 4-9 Purifiers" hidden="false" collective="false" import="false" defaultSelectionEntryId="2105-9372-a043-df0c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4458-9ace-aa41-4ab4" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="832a-b37e-7fa1-9eb3" type="max"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="model" import="true" name="Knight of the Flame" hidden="false" id="d27-4455-b0d4-3250">
+            <selectionEntry id="d27-4455-b0d4-3250" name="Knight of the Flame" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2324-7215-e92a-4b1b"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e341-5b62-dcfd-8b"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2324-7215-e92a-4b1b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e341-5b62-dcfd-8b" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="2d25-3fc9-a477-6a9e">
+                <selectionEntry id="2d25-3fc9-a477-6a9e" name="Nemesis Force Weapon" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="7ae3-9593-7d8-1faa">
+                    <profile id="7ae3-9593-7d8-1faa" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                         <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
@@ -4637,12 +5161,19 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="131a-5b0a-cbcd-a9ff" targetId="e9c4-2bb8-12ee-cd1b"/>
+                    <infoLink id="131a-5b0a-cbcd-a9ff" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="afbf-1390-b3c2-34e5">
+                <selectionEntry id="afbf-1390-b3c2-34e5" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77a-f8d6-ae23-1a1d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+                  </constraints>
                   <profiles>
-                    <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="5feb-7055-7b8f-3c3d">
+                    <profile id="5feb-7055-7b8f-3c3d" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -4655,20 +5186,23 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Rapid Fire" hidden="false" type="rule" id="451c-69a-4cb3-1d5f" targetId="c5c8-8b58-b8b6-7786">
+                    <infoLink id="451c-69a-4cb3-1d5f" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
                       <modifiers>
-                        <modifier type="append" value="2" field="name"/>
+                        <modifier type="append" field="name" value="2"/>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b77a-f8d6-ae23-1a1d"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Purifying Flame" hidden="false" id="7806-2692-1a7b-e5ac" collective="true">
+                <selectionEntry id="7806-2692-1a7b-e5ac" name="Purifying Flame" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a74-db6c-c1f9-6c02" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca48-7264-b8b4-4d77" type="max"/>
+                  </constraints>
                   <profiles>
-                    <profile name="Purifying Flame" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="afa7-73a6-825f-91b1">
+                    <profile id="afa7-73a6-825f-91b1" name="Purifying Flame" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
@@ -4681,30 +5215,32 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Ignores Cover" hidden="false" type="rule" id="2ea9-4251-52bd-c35f" targetId="4640-43e7-30b-215a"/>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="ccdb-ad3-c9b1-68f1" targetId="e9c4-2bb8-12ee-cd1b"/>
-                    <infoLink name="Anti-" hidden="false" type="rule" id="a47c-3e7f-d682-860d" targetId="4111-82e3-9444-e942">
+                    <infoLink id="2ea9-4251-52bd-c35f" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+                    <infoLink id="ccdb-ad3-c9b1-68f1" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                    <infoLink id="a47c-3e7f-d682-860d" name="Anti-" hidden="false" targetId="4111-82e3-9444-e942" type="rule">
                       <modifiers>
-                        <modifier type="append" value="Infantry 2+" field="name"/>
+                        <modifier type="append" field="name" value="Infantry 2+"/>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2a74-db6c-c1f9-6c02"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ca48-7264-b8b4-4d77"/>
-                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Purifier" hidden="false" id="2105-9372-a043-df0c">
+            <selectionEntry id="2105-9372-a043-df0c" name="Purifier" hidden="false" collective="false" import="true" type="model">
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="1cfa-f820-e633-36ef" collective="true">
+                <selectionEntry id="1cfa-f820-e633-36ef" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="c19a-e2ff-2442-59a6">
+                    <profile id="c19a-e2ff-2442-59a6" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                         <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
@@ -4717,12 +5253,19 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="6672-3ad5-3d08-bc81" targetId="e9c4-2bb8-12ee-cd1b"/>
+                    <infoLink id="6672-3ad5-3d08-bc81" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="71f6-9d16-87ce-ad59" collective="true">
+                <selectionEntry id="71f6-9d16-87ce-ad59" name="Storm Bolter" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77a-f8d6-ae23-1a1d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+                  </constraints>
                   <profiles>
-                    <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="476f-c033-e1b5-ce32">
+                    <profile id="476f-c033-e1b5-ce32" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -4735,20 +5278,23 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Rapid Fire" hidden="false" type="rule" id="83c4-93e2-2f7f-b4ae" targetId="c5c8-8b58-b8b6-7786">
+                    <infoLink id="83c4-93e2-2f7f-b4ae" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
                       <modifiers>
-                        <modifier type="append" value="2" field="name"/>
+                        <modifier type="append" field="name" value="2"/>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b77a-f8d6-ae23-1a1d"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Purifying Flame" hidden="false" id="915e-b169-5d19-d77b" collective="true">
+                <selectionEntry id="915e-b169-5d19-d77b" name="Purifying Flame" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36f4-b798-82be-ed98" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b081-8d93-4835-1320" type="max"/>
+                  </constraints>
                   <profiles>
-                    <profile name="Purifying Flame" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="9ab9-d500-9681-14b9">
+                    <profile id="9ab9-d500-9681-14b9" name="Purifying Flame" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
@@ -4761,37 +5307,49 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Ignores Cover" hidden="false" type="rule" id="a584-94b7-5817-3bb" targetId="4640-43e7-30b-215a"/>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="aec5-e2c1-40ee-1fd3" targetId="e9c4-2bb8-12ee-cd1b"/>
-                    <infoLink name="Anti-" hidden="false" type="rule" id="f5a0-605b-ad0f-b0ab" targetId="4111-82e3-9444-e942">
+                    <infoLink id="a584-94b7-5817-3bb" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+                    <infoLink id="aec5-e2c1-40ee-1fd3" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                    <infoLink id="f5a0-605b-ad0f-b0ab" name="Anti-" hidden="false" targetId="4111-82e3-9444-e942" type="rule">
                       <modifiers>
-                        <modifier type="append" value="Infantry 2+" field="name"/>
+                        <modifier type="append" field="name" value="Infantry 2+"/>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="36f4-b798-82be-ed98"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b081-8d93-4835-1320"/>
-                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="5" field="selections" scope="parent" shared="true" id="4458-9ace-aa41-4ab4"/>
-            <constraint type="max" value="10" field="selections" scope="parent" shared="true" id="832a-b37e-7fa1-9eb3"/>
-          </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup name="Heavy weapons" hidden="false" id="4569-57ed-48ff-4b9b">
+            <selectionEntryGroup id="4569-57ed-48ff-4b9b" name="Heavy weapons" hidden="false" collective="false" import="false">
+              <modifiers>
+                <modifier type="set" field="2014-f03a-8c3-8c83" value="4">
+                  <conditions>
+                    <condition field="selections" scope="8865-df22-1629-bf02" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
-                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="2014-f03a-8c3-8c83"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2014-f03a-8c3-8c83" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry type="model" import="true" name="Purifier w/ incinerator" hidden="false" id="a555-f09-9aa6-db71">
+                <selectionEntry id="a555-f09-9aa6-db71" name="Purifier w/ incinerator" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="118b-f81c-692f-de95" type="max"/>
+                  </constraints>
                   <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Incinerator" hidden="false" id="a6c0-754c-4ad1-618" collective="true">
+                    <selectionEntry id="a6c0-754c-4ad1-618" name="Incinerator" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a14-df-f40e-a3c8" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ae9-7bd7-dd9f-73a6" type="max"/>
+                      </constraints>
                       <profiles>
-                        <profile name="Incinerator" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="79c8-30e7-e8a7-fd4d">
+                        <profile id="79c8-30e7-e8a7-fd4d" name="Incinerator" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
@@ -4804,17 +5362,20 @@
                         </profile>
                       </profiles>
                       <infoLinks>
-                        <infoLink name="Ignores Cover" hidden="false" type="rule" id="3953-f017-d6e9-8510" targetId="4640-43e7-30b-215a"/>
-                        <infoLink name="Torrent" hidden="false" type="rule" id="c0e8-3539-991c-13b" targetId="5edf-d619-23e0-9b56"/>
+                        <infoLink id="3953-f017-d6e9-8510" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+                        <infoLink id="c0e8-3539-991c-13b" name="Torrent" hidden="false" targetId="5edf-d619-23e0-9b56" type="rule"/>
                       </infoLinks>
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9a14-df-f40e-a3c8"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7ae9-7bd7-dd9f-73a6"/>
-                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Purifying Flame" hidden="false" id="541f-dcb9-e0a7-ae43" collective="true">
+                    <selectionEntry id="541f-dcb9-e0a7-ae43" name="Purifying Flame" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bea-eb77-64d5-5efa" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b74-6f35-7e15-8dee" type="max"/>
+                      </constraints>
                       <profiles>
-                        <profile name="Purifying Flame" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="bda9-6c80-e51b-9e62">
+                        <profile id="bda9-6c80-e51b-9e62" name="Purifying Flame" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
@@ -4827,32 +5388,38 @@
                         </profile>
                       </profiles>
                       <infoLinks>
-                        <infoLink name="Ignores Cover" hidden="false" type="rule" id="3b81-297c-37da-8dfc" targetId="4640-43e7-30b-215a"/>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="6ba9-69e6-7069-73f9" targetId="e9c4-2bb8-12ee-cd1b"/>
-                        <infoLink name="Anti-" hidden="false" type="rule" id="d10d-80ab-f6ba-ed47" targetId="4111-82e3-9444-e942">
+                        <infoLink id="3b81-297c-37da-8dfc" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+                        <infoLink id="6ba9-69e6-7069-73f9" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                        <infoLink id="d10d-80ab-f6ba-ed47" name="Anti-" hidden="false" targetId="4111-82e3-9444-e942" type="rule">
                           <modifiers>
-                            <modifier type="append" value="Infantry 2+" field="name"/>
+                            <modifier type="append" field="name" value="Infantry 2+"/>
                           </modifiers>
                         </infoLink>
                       </infoLinks>
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bea-eb77-64d5-5efa"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4b74-6f35-7e15-8dee"/>
-                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
-                    <entryLink import="true" name="Close combat weapon" hidden="false" type="selectionEntry" id="8f0e-8d52-1a3c-fd13" targetId="d0e-7460-ee7b-660f"/>
+                    <entryLink id="8f0e-8d52-1a3c-fd13" name="Close combat weapon" hidden="false" collective="false" import="true" targetId="d0e-7460-ee7b-660f" type="selectionEntry"/>
                   </entryLinks>
-                  <constraints>
-                    <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="118b-f81c-692f-de95"/>
-                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="model" import="true" name="Purifier w/ psilencer" hidden="false" id="efc9-77c8-f86a-878d">
+                <selectionEntry id="efc9-77c8-f86a-878d" name="Purifier w/ psilencer" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c31-febc-7c2c-37f7" type="max"/>
+                  </constraints>
                   <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Purifying Flame" hidden="false" id="87af-3056-395b-55ef" collective="true">
+                    <selectionEntry id="87af-3056-395b-55ef" name="Purifying Flame" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bea-eb77-64d5-5efa" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b74-6f35-7e15-8dee" type="max"/>
+                      </constraints>
                       <profiles>
-                        <profile name="Purifying Flame" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="f9a0-628e-ac4d-c9e6">
+                        <profile id="f9a0-628e-ac4d-c9e6" name="Purifying Flame" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
@@ -4865,22 +5432,25 @@
                         </profile>
                       </profiles>
                       <infoLinks>
-                        <infoLink name="Ignores Cover" hidden="false" type="rule" id="710a-fc95-179d-c303" targetId="4640-43e7-30b-215a"/>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="ded0-765f-f964-f638" targetId="e9c4-2bb8-12ee-cd1b"/>
-                        <infoLink name="Anti-" hidden="false" type="rule" id="6193-596b-f5a8-5f00" targetId="4111-82e3-9444-e942">
+                        <infoLink id="710a-fc95-179d-c303" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+                        <infoLink id="ded0-765f-f964-f638" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                        <infoLink id="6193-596b-f5a8-5f00" name="Anti-" hidden="false" targetId="4111-82e3-9444-e942" type="rule">
                           <modifiers>
-                            <modifier type="append" value="Infantry 2+" field="name"/>
+                            <modifier type="append" field="name" value="Infantry 2+"/>
                           </modifiers>
                         </infoLink>
                       </infoLinks>
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bea-eb77-64d5-5efa"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4b74-6f35-7e15-8dee"/>
-                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Psilencer" hidden="false" id="63b3-b175-dd2d-d9bd" collective="true">
+                    <selectionEntry id="63b3-b175-dd2d-d9bd" name="Psilencer" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fbe-63c1-995-87b3" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3cb-37f5-f1f0-15e4" type="max"/>
+                      </constraints>
                       <profiles>
-                        <profile name="Psilencer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="454c-3450-7eb1-d0af">
+                        <profile id="454c-3450-7eb1-d0af" name="Psilencer" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
@@ -4893,31 +5463,37 @@
                         </profile>
                       </profiles>
                       <infoLinks>
-                        <infoLink name="Sustained Hits" hidden="false" type="rule" id="76c4-9af5-3152-c2be" targetId="1897-c22c-9597-12b1">
+                        <infoLink id="76c4-9af5-3152-c2be" name="Sustained Hits" hidden="false" targetId="1897-c22c-9597-12b1" type="rule">
                           <modifiers>
-                            <modifier type="append" value="1" field="name"/>
+                            <modifier type="append" field="name" value="1"/>
                           </modifiers>
                         </infoLink>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="f2d9-4a9d-4ac2-1819" targetId="e9c4-2bb8-12ee-cd1b"/>
+                        <infoLink id="f2d9-4a9d-4ac2-1819" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
                       </infoLinks>
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6fbe-63c1-995-87b3"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e3cb-37f5-f1f0-15e4"/>
-                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
-                    <entryLink import="true" name="Close combat weapon" hidden="false" type="selectionEntry" id="8efa-e201-4f83-8b36" targetId="d0e-7460-ee7b-660f"/>
+                    <entryLink id="8efa-e201-4f83-8b36" name="Close combat weapon" hidden="false" collective="false" import="true" targetId="d0e-7460-ee7b-660f" type="selectionEntry"/>
                   </entryLinks>
-                  <constraints>
-                    <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="1c31-febc-7c2c-37f7"/>
-                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="model" import="true" name="Purifier w/ psycannon" hidden="false" id="d518-3382-8614-960b">
+                <selectionEntry id="d518-3382-8614-960b" name="Purifier w/ psycannon" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e1e-b436-7ba2-c898" type="max"/>
+                  </constraints>
                   <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Purifying Flame" hidden="false" id="6ef7-1774-e655-9480" collective="true">
+                    <selectionEntry id="6ef7-1774-e655-9480" name="Purifying Flame" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bea-eb77-64d5-5efa" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b74-6f35-7e15-8dee" type="max"/>
+                      </constraints>
                       <profiles>
-                        <profile name="Purifying Flame" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="223f-9c61-6d39-228f">
+                        <profile id="223f-9c61-6d39-228f" name="Purifying Flame" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
@@ -4930,25 +5506,25 @@
                         </profile>
                       </profiles>
                       <infoLinks>
-                        <infoLink name="Ignores Cover" hidden="false" type="rule" id="b128-ff8-c7e5-a21e" targetId="4640-43e7-30b-215a"/>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="968c-3cb5-4eef-a3e2" targetId="e9c4-2bb8-12ee-cd1b"/>
-                        <infoLink name="Anti-" hidden="false" type="rule" id="73e9-c4e8-932b-e742" targetId="4111-82e3-9444-e942">
+                        <infoLink id="b128-ff8-c7e5-a21e" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+                        <infoLink id="968c-3cb5-4eef-a3e2" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                        <infoLink id="73e9-c4e8-932b-e742" name="Anti-" hidden="false" targetId="4111-82e3-9444-e942" type="rule">
                           <modifiers>
-                            <modifier type="append" value="Infantry 2+" field="name"/>
+                            <modifier type="append" field="name" value="Infantry 2+"/>
                           </modifiers>
                         </infoLink>
                       </infoLinks>
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bea-eb77-64d5-5efa"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4b74-6f35-7e15-8dee"/>
-                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Psycannon" hidden="false" id="28a-e8f4-7397-9e36" collective="true">
-                      <infoLinks>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="fb66-230b-d8f8-6180" targetId="e9c4-2bb8-12ee-cd1b"/>
-                      </infoLinks>
+                    <selectionEntry id="28a-e8f4-7397-9e36" name="Psycannon" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a462-b2b3-9317-1a00" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43cb-aaec-a3ad-c9d7" type="max"/>
+                      </constraints>
                       <profiles>
-                        <profile name="Psycannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="ae1b-164f-4af5-c81a">
+                        <profile id="ae1b-164f-4af5-c81a" name="Psycannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
@@ -4960,43 +5536,33 @@
                           </characteristics>
                         </profile>
                       </profiles>
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a462-b2b3-9317-1a00"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="43cb-aaec-a3ad-c9d7"/>
-                      </constraints>
+                      <infoLinks>
+                        <infoLink id="fb66-230b-d8f8-6180" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
-                    <entryLink import="true" name="Close combat weapon" hidden="false" type="selectionEntry" id="5cce-9fcf-8124-a298" targetId="d0e-7460-ee7b-660f"/>
+                    <entryLink id="5cce-9fcf-8124-a298" name="Close combat weapon" hidden="false" collective="false" import="true" targetId="d0e-7460-ee7b-660f" type="selectionEntry"/>
                   </entryLinks>
-                  <constraints>
-                    <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="4e1e-b436-7ba2-c898"/>
-                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
-              <modifiers>
-                <modifier type="set" value="4" field="2014-f03a-8c3-8c83" id="4419-42c9-afdb-4583">
-                  <conditions>
-                    <condition type="atLeast" value="10" field="selections" scope="8865-df22-1629-bf02" childId="model" shared="true" id="8ee1-8db8-b65-2c1c" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
             </selectionEntryGroup>
           </selectionEntryGroups>
         </selectionEntryGroup>
       </selectionEntryGroups>
-    </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Servitors" hidden="false" id="35ed-7890-6c56-18b7">
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="50"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="130.0"/>
       </costs>
-      <categoryLinks>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="59fa-932e-54-6dd9" primary="true" name="Infantry"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="e0dc-789d-5fd-afb9" primary="false" name="Imperium"/>
-        <categoryLink targetId="5bc8-a8b7-1c69-9043" id="ed8a-cca3-26cb-7861" primary="false" name="Servitors"/>
-      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry id="35ed-7890-6c56-18b7" name="Servitors" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile name="Servitors" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="41f2-5bed-a5f3-81ed">
+        <profile id="41f2-5bed-a5f3-81ed" name="Servitors" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">6&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">4</characteristic>
@@ -5006,34 +5572,43 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">0</characteristic>
           </characteristics>
         </profile>
-        <profile name="Invulnerable Save (6+)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="290c-4f4a-2c2d-a095">
+        <profile id="290c-4f4a-2c2d-a095" name="Invulnerable Save (6+)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This unit has a 6+ Invulnerable Save</characteristic>
           </characteristics>
         </profile>
-        <profile name="Mindlock" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="685-c0a5-139e-a916">
+        <profile id="685-c0a5-139e-a916" name="Mindlock" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While a BROTHERHOOD TECHMARINE model is leading this unit, improve the Ballistic Skill and Weapon Skill characteristics of ranged and melee weapons equipped by Servitor models in this unit by 1</characteristic>
           </characteristics>
         </profile>
-        <profile name="Retinue" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="ae16-1ed-ea16-9713">
+        <profile id="ae16-1ed-ea16-9713" name="Retinue" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While a BROTHERHOOD TECHMARINE model is leading this unit, models in this unit have the Deep Strike and Teleport Assault abilities</characteristic>
           </characteristics>
         </profile>
       </profiles>
+      <categoryLinks>
+        <categoryLink id="59fa-932e-54-6dd9" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="true"/>
+        <categoryLink id="e0dc-789d-5fd-afb9" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="ed8a-cca3-26cb-7861" name="Servitors" hidden="false" targetId="5bc8-a8b7-1c69-9043" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup name="4 Servitors" hidden="false" id="aa0e-aa31-d253-7c03" defaultSelectionEntryId="54c6-2506-f109-dd">
+        <selectionEntryGroup id="aa0e-aa31-d253-7c03" name="4 Servitors" hidden="false" collective="false" import="false" defaultSelectionEntryId="54c6-2506-f109-dd">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a616-574d-b183-5e9c" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f2d-3454-1dfe-a92a" type="max"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="model" import="true" name="Servitor with Servo Arm" hidden="false" id="54c6-2506-f109-dd">
+            <selectionEntry id="54c6-2506-f109-dd" name="Servitor with Servo Arm" hidden="false" collective="false" import="true" type="model">
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Servo arm" hidden="false" id="9917-e322-6c2e-6b8b" collective="true">
+                <selectionEntry id="9917-e322-6c2e-6b8b" name="Servo arm" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="aea9-cee7-8a64-a1f6-min"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="aea9-cee7-8a64-a1f6-max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aea9-cee7-8a64-a1f6-min" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aea9-cee7-8a64-a1f6-max" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile name="Servo Arm" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="d0b3-ac83-269a-4623">
+                    <profile id="d0b3-ac83-269a-4623" name="Servo Arm" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                         <characteristic name="A" typeId="2337-daa1-6682-b110">1</characteristic>
@@ -5045,18 +5620,24 @@
                       </characteristics>
                     </profile>
                   </profiles>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Servitor with Heavy Bolter" hidden="false" id="89c9-ccee-d41e-7489">
+            <selectionEntry id="89c9-ccee-d41e-7489" name="Servitor with Heavy Bolter" hidden="false" collective="false" import="true" type="model">
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Heavy bolter" hidden="false" id="1e2f-fd28-c358-44fa" collective="true">
+                <selectionEntry id="1e2f-fd28-c358-44fa" name="Heavy bolter" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5238-5ec-75fa-3c4a-min"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5238-5ec-75fa-3c4a-max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5238-5ec-75fa-3c4a-min" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5238-5ec-75fa-3c4a-max" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile name="Heavy bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="beeb-ce7d-c08a-2f6b">
+                    <profile id="beeb-ce7d-c08a-2f6b" name="Heavy bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
@@ -5069,27 +5650,30 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Heavy" hidden="false" type="rule" id="c1af-8baa-4965-c1b0" targetId="1202-10a8-78e9-4c67"/>
-                    <infoLink name="Sustained Hits" hidden="false" type="rule" id="b8f9-85f7-ad62-1266" targetId="1897-c22c-9597-12b1"/>
+                    <infoLink id="c1af-8baa-4965-c1b0" name="Heavy" hidden="false" targetId="1202-10a8-78e9-4c67" type="rule"/>
+                    <infoLink id="b8f9-85f7-ad62-1266" name="Sustained Hits" hidden="false" targetId="1897-c22c-9597-12b1" type="rule"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink import="true" name="Servitor&apos;s tools" hidden="false" type="selectionEntry" id="ff82-48b8-9bcf-eacc" targetId="bc82-5462-1e1-5008"/>
+                <entryLink id="ff82-48b8-9bcf-eacc" name="Servitor&apos;s tools" hidden="false" collective="false" import="true" targetId="bc82-5462-1e1-5008" type="selectionEntry"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Servitor with Multi Melta" hidden="false" id="51b4-7283-dda-f124">
-              <entryLinks>
-                <entryLink import="true" name="Servitor&apos;s tools" hidden="false" type="selectionEntry" id="4a36-fb45-82f6-8bb2" targetId="bc82-5462-1e1-5008"/>
-              </entryLinks>
+            <selectionEntry id="51b4-7283-dda-f124" name="Servitor with Multi Melta" hidden="false" collective="false" import="true" type="model">
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Multi-melta" hidden="false" id="c5a6-642e-8e30-ffeb" collective="true">
+                <selectionEntry id="c5a6-642e-8e30-ffeb" name="Multi-melta" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2d4b-7494-ecda-1e1f-min"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2d4b-7494-ecda-1e1f-max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d4b-7494-ecda-1e1f-min" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d4b-7494-ecda-1e1f-max" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile name="Multi-Melta" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="543e-7730-cfbd-b972">
+                    <profile id="543e-7730-cfbd-b972" name="Multi-Melta" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -5102,23 +5686,29 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Melta" hidden="false" type="rule" id="5ac3-b4fe-e147-a777" targetId="7cdb-fb99-44a9-8849"/>
+                    <infoLink id="5ac3-b4fe-e147-a777" name="Melta" hidden="false" targetId="7cdb-fb99-44a9-8849" type="rule"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
-            </selectionEntry>
-            <selectionEntry type="model" import="true" name="Servitor with Plasma Cannon" hidden="false" id="40ff-1eb6-2299-f733">
               <entryLinks>
-                <entryLink import="true" name="Servitor&apos;s tools" hidden="false" type="selectionEntry" id="65c3-ea9-ae3-2e9a" targetId="bc82-5462-1e1-5008"/>
+                <entryLink id="4a36-fb45-82f6-8bb2" name="Servitor&apos;s tools" hidden="false" collective="false" import="true" targetId="bc82-5462-1e1-5008" type="selectionEntry"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="40ff-1eb6-2299-f733" name="Servitor with Plasma Cannon" hidden="false" collective="false" import="true" type="model">
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Plasma cannon" hidden="false" id="95b0-877b-2f1e-6292" collective="true">
+                <selectionEntry id="95b0-877b-2f1e-6292" name="Plasma cannon" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2cd8-7e67-3aa8-f0b2-min"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2cd8-7e67-3aa8-f0b2-max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cd8-7e67-3aa8-f0b2-min" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cd8-7e67-3aa8-f0b2-max" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile name="➤ Plasma Cannon - standard" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="8167-f21b-fd1e-c595">
+                    <profile id="8167-f21b-fd1e-c595" name="➤ Plasma Cannon - standard" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">D3</characteristic>
@@ -5129,7 +5719,7 @@
                         <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast, Heavy</characteristic>
                       </characteristics>
                     </profile>
-                    <profile name="➤ Plasma Cannon - supercharge" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="788-1910-4e77-6a62">
+                    <profile id="788-1910-4e77-6a62" name="➤ Plasma Cannon - supercharge" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">D3</characteristic>
@@ -5142,43 +5732,39 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Heavy" hidden="false" type="rule" id="eb44-e805-eb63-8ac7" targetId="1202-10a8-78e9-4c67"/>
-                    <infoLink name="Blast" hidden="false" type="rule" id="de33-609c-8805-1378" targetId="6c1f-1cf7-ff25-c99e"/>
-                    <infoLink name="Hazardous" hidden="false" type="rule" id="cc5a-3d42-c149-dbbb" targetId="8367-374c-f87-c627"/>
+                    <infoLink id="eb44-e805-eb63-8ac7" name="Heavy" hidden="false" targetId="1202-10a8-78e9-4c67" type="rule"/>
+                    <infoLink id="de33-609c-8805-1378" name="Blast" hidden="false" targetId="6c1f-1cf7-ff25-c99e" type="rule"/>
+                    <infoLink id="cc5a-3d42-c149-dbbb" name="Hazardous" hidden="false" targetId="8367-374c-f87-c627" type="rule"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
+              <entryLinks>
+                <entryLink id="65c3-ea9-ae3-2e9a" name="Servitor&apos;s tools" hidden="false" collective="false" import="true" targetId="bc82-5462-1e1-5008" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="4" field="selections" scope="parent" shared="true" id="a616-574d-b183-5e9c"/>
-            <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="1f2d-3454-1dfe-a92a"/>
-          </constraints>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="50.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Strike Squad" hidden="false" id="d81f-c9ac-e338-ba37">
+    <selectionEntry id="d81f-c9ac-e338-ba37" name="Strike Squad" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="set" value="250" field="51b2-306e-1021-d207">
+        <modifier type="set" field="51b2-306e-1021-d207" value="250">
           <conditions>
-            <condition type="atLeast" value="6" field="selections" scope="d81f-c9ac-e338-ba37" childId="model" shared="true"/>
+            <condition field="selections" scope="d81f-c9ac-e338-ba37" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
           </conditions>
         </modifier>
       </modifiers>
-      <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="125"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="103f-a8cd-8c1f-24df" id="a64-53d7-6787-e0a5" primary="false" name="Strike Squad"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="30b-760-3ebd-e914" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="13bf-2bee-3ae0-b414" id="4d6a-6393-268-94c4" primary="false" name="Psyker"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="7909-7ea1-f441-9a4c" primary="false" name="Imperium"/>
-        <categoryLink targetId="5a61-81ac-eb7c-a87e" id="39cb-2fde-7425-74aa" primary="false" name="Grenades"/>
-        <categoryLink targetId="e338-111e-d0c6-b687" id="8361-187b-92bb-d324" primary="true" name="Battleline"/>
-        <categoryLink targetId="cf47-a0d7-7207-29dc" id="baf3-3c52-b9aa-3855" primary="false" name="Infantry"/>
-      </categoryLinks>
       <profiles>
-        <profile name="Strike Squad" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="3d57-16ca-bf72-e43a">
+        <profile id="3d57-16ca-bf72-e43a" name="Strike Squad" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">6&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">4</characteristic>
@@ -5188,36 +5774,49 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">2</characteristic>
           </characteristics>
         </profile>
-        <profile name="Sanctifying Ritual (Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="e301-c532-9ade-1060">
+        <profile id="e301-c532-9ade-1060" name="Sanctifying Ritual (Psychic)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">If you control an objective marker at the end of your Command phase and this unit is within range of that objective marker, that objective marker remains under you control, even if you have no models within range of it, until your opponent controls it at the start or end of any turn</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Deep Strike" hidden="false" type="rule" id="2f18-cd5-2ec-a1d2" targetId="7cb5-dd6b-dd87-ad3b"/>
-        <infoLink name="Scouts" hidden="false" type="rule" id="58af-315b-6ac8-d3ac" targetId="ada6-bac1-ffe0-d6f7">
+        <infoLink id="2f18-cd5-2ec-a1d2" name="Deep Strike" hidden="false" targetId="7cb5-dd6b-dd87-ad3b" type="rule"/>
+        <infoLink id="58af-315b-6ac8-d3ac" name="Scouts" hidden="false" targetId="ada6-bac1-ffe0-d6f7" type="rule">
           <modifiers>
-            <modifier type="append" value="6&quot;" field="name"/>
+            <modifier type="append" field="name" value="6&quot;"/>
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a64-53d7-6787-e0a5" name="Strike Squad" hidden="false" targetId="103f-a8cd-8c1f-24df" primary="false"/>
+        <categoryLink id="30b-760-3ebd-e914" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="4d6a-6393-268-94c4" name="Psyker" hidden="false" targetId="13bf-2bee-3ae0-b414" primary="false"/>
+        <categoryLink id="7909-7ea1-f441-9a4c" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="39cb-2fde-7425-74aa" name="Grenades" hidden="false" targetId="5a61-81ac-eb7c-a87e" primary="false"/>
+        <categoryLink id="8361-187b-92bb-d324" name="Battleline" hidden="false" targetId="e338-111e-d0c6-b687" primary="true"/>
+        <categoryLink id="baf3-3c52-b9aa-3855" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup name="1 Justicar and 4-9 Grey Knights" hidden="false" id="38d6-858d-42f5-c38d" defaultSelectionEntryId="2e8c-d8a7-b77c-d2ad">
+        <selectionEntryGroup id="38d6-858d-42f5-c38d" name="1 Justicar and 4-9 Grey Knights" hidden="false" collective="false" import="false" defaultSelectionEntryId="2e8c-d8a7-b77c-d2ad">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4458-9ace-aa41-4ab4" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="832a-b37e-7fa1-9eb3" type="max"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="model" import="true" name="Justicar" hidden="false" id="e94e-2f1d-3d5b-dad8">
+            <selectionEntry id="e94e-2f1d-3d5b-dad8" name="Justicar" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2324-7215-e92a-4b1b"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e341-5b62-dcfd-8b"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2324-7215-e92a-4b1b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e341-5b62-dcfd-8b" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="a2ae-bf4f-7273-439">
+                <selectionEntry id="a2ae-bf4f-7273-439" name="Nemesis Force Weapon" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="9f39-7f88-e55b-5621">
+                    <profile id="9f39-7f88-e55b-5621" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                         <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
@@ -5230,12 +5829,19 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="b49c-a7cd-1f9f-7951" targetId="e9c4-2bb8-12ee-cd1b"/>
+                    <infoLink id="b49c-a7cd-1f9f-7951" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="b26a-29d2-ce3f-6f95">
+                <selectionEntry id="b26a-29d2-ce3f-6f95" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77a-f8d6-ae23-1a1d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+                  </constraints>
                   <profiles>
-                    <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="849c-b659-147c-f45d">
+                    <profile id="849c-b659-147c-f45d" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -5248,28 +5854,30 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Rapid Fire" hidden="false" type="rule" id="8396-e701-957d-1ead" targetId="c5c8-8b58-b8b6-7786">
+                    <infoLink id="8396-e701-957d-1ead" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
                       <modifiers>
-                        <modifier type="append" value="2" field="name"/>
+                        <modifier type="append" field="name" value="2"/>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b77a-f8d6-ae23-1a1d"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Grey Knight" hidden="false" id="2e8c-d8a7-b77c-d2ad">
+            <selectionEntry id="2e8c-d8a7-b77c-d2ad" name="Grey Knight" hidden="false" collective="false" import="true" type="model">
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Nemesis Force Weapon" hidden="false" id="d183-5a5f-7559-66ad" collective="true">
+                <selectionEntry id="d183-5a5f-7559-66ad" name="Nemesis Force Weapon" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d0c8-c2d9-a054-2f27"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aa3-e87e-a141-5d6d"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c8-c2d9-a054-2f27" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa3-e87e-a141-5d6d" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile name="Nemesis Force Weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="2228-faef-2090-b5a0">
+                    <profile id="2228-faef-2090-b5a0" name="Nemesis Force Weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
                         <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
@@ -5282,12 +5890,19 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Psychic" hidden="false" type="rule" id="5f92-6738-1cae-94eb" targetId="e9c4-2bb8-12ee-cd1b"/>
+                    <infoLink id="5f92-6738-1cae-94eb" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="2ba5-c2d6-adb5-77f4" collective="true">
+                <selectionEntry id="2ba5-c2d6-adb5-77f4" name="Storm Bolter" hidden="false" collective="true" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77a-f8d6-ae23-1a1d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f67-dea-4484-d7bc" type="max"/>
+                  </constraints>
                   <profiles>
-                    <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="517d-d02e-6624-c935">
+                    <profile id="517d-d02e-6624-c935" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                       <characteristics>
                         <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                         <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -5300,29 +5915,42 @@
                     </profile>
                   </profiles>
                   <infoLinks>
-                    <infoLink name="Rapid Fire" hidden="false" type="rule" id="3a16-a314-f235-8a79" targetId="c5c8-8b58-b8b6-7786">
+                    <infoLink id="3a16-a314-f235-8a79" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
                       <modifiers>
-                        <modifier type="append" value="2" field="name"/>
+                        <modifier type="append" field="name" value="2"/>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b77a-f8d6-ae23-1a1d"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6f67-dea-4484-d7bc"/>
-                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Grey Knight with Heavy Weapon" hidden="false" id="b953-5c1a-5d31-192f">
+            <selectionEntry id="b953-5c1a-5d31-192f" name="Grey Knight with Heavy Weapon" hidden="false" collective="false" import="true" type="model">
+              <modifiers>
+                <modifier type="set" field="702-d447-314b-a3f6" value="2">
+                  <conditions>
+                    <condition field="selections" scope="d81f-c9ac-e338-ba37" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="702-d447-314b-a3f6" type="max"/>
+              </constraints>
               <selectionEntryGroups>
-                <selectionEntryGroup name="Weapon Choice" hidden="false" id="c5d2-640d-6bd-6b71" defaultSelectionEntryId="9f4a-4baa-324c-7904">
+                <selectionEntryGroup id="c5d2-640d-6bd-6b71" name="Weapon Choice" hidden="false" collective="false" import="false" defaultSelectionEntryId="9f4a-4baa-324c-7904">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91fc-5d4d-70a1-955f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b66e-ec0f-231-9d5f" type="max"/>
+                  </constraints>
                   <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Psycannon" hidden="false" id="9f4a-4baa-324c-7904">
-                      <infoLinks>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="1911-b2e8-28f9-5d9a" targetId="e9c4-2bb8-12ee-cd1b"/>
-                      </infoLinks>
+                    <selectionEntry id="9f4a-4baa-324c-7904" name="Psycannon" hidden="false" collective="false" import="true" type="upgrade">
                       <profiles>
-                        <profile name="Psycannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="8c1c-4387-9c82-4780">
+                        <profile id="8c1c-4387-9c82-4780" name="Psycannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
@@ -5334,10 +5962,16 @@
                           </characteristics>
                         </profile>
                       </profiles>
+                      <infoLinks>
+                        <infoLink id="1911-b2e8-28f9-5d9a" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Incinerator" hidden="false" id="f37f-228a-a9-1b00">
+                    <selectionEntry id="f37f-228a-a9-1b00" name="Incinerator" hidden="false" collective="false" import="true" type="upgrade">
                       <profiles>
-                        <profile name="Incinerator" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="76e8-7d80-5eeb-c5dc">
+                        <profile id="76e8-7d80-5eeb-c5dc" name="Incinerator" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
@@ -5350,13 +5984,16 @@
                         </profile>
                       </profiles>
                       <infoLinks>
-                        <infoLink name="Ignores Cover" hidden="false" type="rule" id="1d05-eeaa-b570-9e3f" targetId="4640-43e7-30b-215a"/>
-                        <infoLink name="Torrent" hidden="false" type="rule" id="54d2-93d4-1b97-ce46" targetId="5edf-d619-23e0-9b56"/>
+                        <infoLink id="1d05-eeaa-b570-9e3f" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+                        <infoLink id="54d2-93d4-1b97-ce46" name="Torrent" hidden="false" targetId="5edf-d619-23e0-9b56" type="rule"/>
                       </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Psilencer" hidden="false" id="d045-399e-966c-c019">
+                    <selectionEntry id="d045-399e-966c-c019" name="Psilencer" hidden="false" collective="false" import="true" type="upgrade">
                       <profiles>
-                        <profile name="Psilencer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="f604-664c-eee3-6c40">
+                        <profile id="f604-664c-eee3-6c40" name="Psilencer" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
                           <characteristics>
                             <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                             <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
@@ -5369,56 +6006,34 @@
                         </profile>
                       </profiles>
                       <infoLinks>
-                        <infoLink name="Sustained Hits" hidden="false" type="rule" id="cfe5-5fd0-933a-77ef" targetId="1897-c22c-9597-12b1">
+                        <infoLink id="cfe5-5fd0-933a-77ef" name="Sustained Hits" hidden="false" targetId="1897-c22c-9597-12b1" type="rule">
                           <modifiers>
-                            <modifier type="append" value="1" field="name"/>
+                            <modifier type="append" field="name" value="1"/>
                           </modifiers>
                         </infoLink>
-                        <infoLink name="Psychic" hidden="false" type="rule" id="5b4a-9b8d-50f8-1357" targetId="e9c4-2bb8-12ee-cd1b"/>
+                        <infoLink id="5b4a-9b8d-50f8-1357" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
                       </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="91fc-5d4d-70a1-955f"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b66e-ec0f-231-9d5f"/>
-                  </constraints>
                 </selectionEntryGroup>
               </selectionEntryGroups>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="702-d447-314b-a3f6"/>
-              </constraints>
-              <modifiers>
-                <modifier type="set" value="2" field="702-d447-314b-a3f6">
-                  <conditions>
-                    <condition type="atLeast" value="10" field="selections" scope="d81f-c9ac-e338-ba37" childId="model" shared="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="5" field="selections" scope="parent" shared="true" id="4458-9ace-aa41-4ab4"/>
-            <constraint type="max" value="10" field="selections" scope="parent" shared="true" id="832a-b37e-7fa1-9eb3"/>
-          </constraints>
         </selectionEntryGroup>
       </selectionEntryGroups>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Grey Knights Thunderhawk Gunship" hidden="false" id="8989-2fd2-4d29-e795">
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="805"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="125.0"/>
       </costs>
-      <categoryLinks>
-        <categoryLink targetId="f580-2968-19f3-1320" id="ccf9-c49a-7bc-b775" primary="false" name="Grey Knights Thunderhawk Gunship"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="bcb6-cea5-c765-20cf" primary="false" name="Faction: Grey Knights"/>
-        <categoryLink targetId="5929-ad51-d006-e008" id="52f-65a7-bbe2-947a" primary="false" name="Titanic"/>
-        <categoryLink targetId="dbd4-63-af05-998" id="fb85-6dd6-d084-48b4" primary="true" name="Vehicle"/>
-        <categoryLink targetId="c619-2086-bbcf-69c9" id="d3b0-496c-161b-3b62" primary="false" name="Fly"/>
-        <categoryLink targetId="75e8-57c4-40e3-1817" id="deb1-b10d-3e67-3c72" primary="false" name="Transport"/>
-        <categoryLink targetId="63f1-e6e8-f6f6-a4f0" id="1c7c-e61d-ccb6-8d17" primary="false" name="Aircraft"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="e973-f71f-d183-3600" primary="false" name="Imperium"/>
-      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry id="8989-2fd2-4d29-e795" name="Grey Knights Thunderhawk Gunship" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile name="Grey Knights Thunderhawk Gunship" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="357b-e9fc-505d-c82d">
+        <profile id="357b-e9fc-505d-c82d" name="Grey Knights Thunderhawk Gunship" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">20+&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">12</characteristic>
@@ -5428,22 +6043,22 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">0</characteristic>
           </characteristics>
         </profile>
-        <profile name="Grey Knights Thunderhawk Gunship" typeId="74f8-5443-9d6d-1f1e" typeName="Transport" hidden="false" id="9978-7aa5-9a2c-6eb5">
+        <profile id="9978-7aa5-9a2c-6eb5" name="Grey Knights Thunderhawk Gunship" hidden="false" typeId="74f8-5443-9d6d-1f1e" typeName="Transport">
           <characteristics>
             <characteristic name="Capacity" typeId="30f2-be70-861d-1b84">This model has a transport capacity of 30 Grey Knights Infantry models. Each Terminator model takes up the space of 2 models.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Damaged: 1-10 Wounds Remaining" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="dae-a965-1e6d-d79a">
+        <profile id="dae-a965-1e6d-d79a" name="Damaged: 1-10 Wounds Remaining" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-10 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Aerial Assault" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="86b2-1076-cbe6-c46b">
+        <profile id="86b2-1076-cbe6-c46b" name="Aerial Assault" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a unit with the Deep Strike ability disembarks from this model after it has made a Normal move, that unit is still eligible to declare a charge this turn</characteristic>
           </characteristics>
         </profile>
-        <profile name="Armored Hull" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="e9be-6b58-f0bd-9a1f">
+        <profile id="e9be-6b58-f0bd-9a1f" name="Armored Hull" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
           <characteristics>
             <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
             <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
@@ -5455,107 +6070,32 @@
           </characteristics>
         </profile>
       </profiles>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Weapon Option 2" hidden="false" id="62e4-b3ee-99d2-acd8" defaultSelectionEntryId="28cf-e229-c9bb-bf44">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Thunderhawk Cluster Bombs" hidden="false" id="28cf-e229-c9bb-bf44">
-              <profiles>
-                <profile name="Thunderhawk Cluster Bombs" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="66fc-3811-9adc-d285">
-                  <characteristics>
-                    <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time the bearer ends a Normal move, you can select one enemy unit it moved over during that move and roll six D6: for each 3+, that unit suffers 1 mortal wound.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Hellstrike Missile Battery" hidden="false" id="df1c-ece9-8eb1-3097">
-              <profiles>
-                <profile name="Hellstrike Missile Battery" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="93c3-67b4-925f-c9f2">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">72&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">4</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">3</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Anti-Fly 4+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink name="Anti-" hidden="false" type="rule" id="78d7-8aa-e1eb-9b3c" targetId="4111-82e3-9444-e942">
-                  <modifiers>
-                    <modifier type="append" value="Fly 4+" field="name"/>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="50c2-b086-bf8e-8b60"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="304f-45e6-718a-dd0b"/>
-          </constraints>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Weapon Option 1" hidden="false" id="9454-4e15-37f4-199a" defaultSelectionEntryId="3c9f-6ed1-99f7-463b">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Thunderhawk Heavy Cannon" hidden="false" id="3c9f-6ed1-99f7-463b">
-              <profiles>
-                <profile name="Thunderhawk Heavy Cannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="27fe-af10-946e-78ed">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6+6</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">10</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">3</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink name="Blast" hidden="false" type="rule" id="f253-20cb-fad8-c292" targetId="6c1f-1cf7-ff25-c99e"/>
-              </infoLinks>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Turbo-Laser Destructor" hidden="false" id="dfd7-add7-ed5a-f2f">
-              <profiles>
-                <profile name="Turbo-Laser Destructor" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="2ac2-e8ff-d331-eb78">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">96&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D3+1</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">20</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+6</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink name="Blast" hidden="false" type="rule" id="e672-9b28-7031-6a72" targetId="6c1f-1cf7-ff25-c99e"/>
-              </infoLinks>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a946-3a42-f8b0-c5b4"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="56bd-2fcd-8828-4c04"/>
-          </constraints>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <infoLinks>
-        <infoLink name="Hover" hidden="false" type="rule" id="a2aa-126f-6713-a2a4" targetId="eec5-5f54-9c03-c305"/>
-        <infoLink name="Deadly Demise" hidden="false" type="rule" id="1n5y-a8k0-z3t6-zzo1" targetId="b68a-5ded-65ac-98c">
+        <infoLink id="a2aa-126f-6713-a2a4" name="Hover" hidden="false" targetId="eec5-5f54-9c03-c305" type="rule"/>
+        <infoLink id="1n5y-a8k0-z3t6-zzo1" name="Deadly Demise" hidden="false" targetId="b68a-5ded-65ac-98c" type="rule">
           <modifiers>
-            <modifier type="append" value="D6+2" field="name"/>
+            <modifier type="append" field="name" value="D6+2"/>
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ccf9-c49a-7bc-b775" name="Grey Knights Thunderhawk Gunship" hidden="false" targetId="f580-2968-19f3-1320" primary="false"/>
+        <categoryLink id="bcb6-cea5-c765-20cf" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+        <categoryLink id="52f-65a7-bbe2-947a" name="Titanic" hidden="false" targetId="5929-ad51-d006-e008" primary="false"/>
+        <categoryLink id="fb85-6dd6-d084-48b4" name="Vehicle" hidden="false" targetId="dbd4-63-af05-998" primary="true"/>
+        <categoryLink id="d3b0-496c-161b-3b62" name="Fly" hidden="false" targetId="c619-2086-bbcf-69c9" primary="false"/>
+        <categoryLink id="deb1-b10d-3e67-3c72" name="Transport" hidden="false" targetId="75e8-57c4-40e3-1817" primary="false"/>
+        <categoryLink id="1c7c-e61d-ccb6-8d17" name="Aircraft" hidden="false" targetId="63f1-e6e8-f6f6-a4f0" primary="false"/>
+        <categoryLink id="e973-f71f-d183-3600" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Lascannon" hidden="false" id="a62e-6c83-e169-20ec">
+        <selectionEntry id="a62e-6c83-e169-20ec" name="Lascannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="ae8a-c446-3666-be5a"/>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="54d2-d4dc-24c1-4ccc"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae8a-c446-3666-be5a" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54d2-d4dc-24c1-4ccc" type="max"/>
           </constraints>
           <profiles>
-            <profile name="Lascannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="fdc6-4762-3739-adb6">
+            <profile id="fdc6-4762-3739-adb6" name="Lascannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
@@ -5567,14 +6107,17 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Twin Heavy Bolter" hidden="false" id="e0b3-6c91-4b73-f83b">
+        <selectionEntry id="e0b3-6c91-4b73-f83b" name="Twin Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="4" field="selections" scope="parent" shared="true" id="ae8a-c446-3666-be5a"/>
-            <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="54d2-d4dc-24c1-4ccc"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae8a-c446-3666-be5a" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54d2-d4dc-24c1-4ccc" type="max"/>
           </constraints>
           <profiles>
-            <profile name="Twin Heavy Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="926a-4709-f329-f3a8">
+            <profile id="926a-4709-f329-f3a8" name="Twin Heavy Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
@@ -5587,30 +6130,122 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Twin-linked" hidden="false" type="rule" id="df0e-10bf-b64d-325a" targetId="cf93-ad4d-2f08-a79d"/>
-            <infoLink name="Sustained Hits" hidden="false" type="rule" id="4120-21e3-736-d4a0" targetId="1897-c22c-9597-12b1">
+            <infoLink id="df0e-10bf-b64d-325a" name="Twin-linked" hidden="false" targetId="cf93-ad4d-2f08-a79d" type="rule"/>
+            <infoLink id="4120-21e3-736-d4a0" name="Sustained Hits" hidden="false" targetId="1897-c22c-9597-12b1" type="rule">
               <modifiers>
-                <modifier type="append" value="1" field="name"/>
+                <modifier type="append" field="name" value="1"/>
               </modifiers>
             </infoLink>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
-    </selectionEntry>
-    <selectionEntry type="model" import="true" name="Land Raider Banisher" hidden="false" id="69d-a656-fde3-6c3e">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="62e4-b3ee-99d2-acd8" name="Weapon Option 2" hidden="false" collective="false" import="false" defaultSelectionEntryId="28cf-e229-c9bb-bf44">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50c2-b086-bf8e-8b60" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="304f-45e6-718a-dd0b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="28cf-e229-c9bb-bf44" name="Thunderhawk Cluster Bombs" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="66fc-3811-9adc-d285" name="Thunderhawk Cluster Bombs" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+                  <characteristics>
+                    <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time the bearer ends a Normal move, you can select one enemy unit it moved over during that move and roll six D6: for each 3+, that unit suffers 1 mortal wound.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="df1c-ece9-8eb1-3097" name="Hellstrike Missile Battery" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="93c3-67b4-925f-c9f2" name="Hellstrike Missile Battery" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">72&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">4</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">3</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Anti-Fly 4+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="78d7-8aa-e1eb-9b3c" name="Anti-" hidden="false" targetId="4111-82e3-9444-e942" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value="Fly 4+"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9454-4e15-37f4-199a" name="Weapon Option 1" hidden="false" collective="false" import="false" defaultSelectionEntryId="3c9f-6ed1-99f7-463b">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a946-3a42-f8b0-c5b4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56bd-2fcd-8828-4c04" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3c9f-6ed1-99f7-463b" name="Thunderhawk Heavy Cannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="27fe-af10-946e-78ed" name="Thunderhawk Heavy Cannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6+6</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">10</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">3</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="f253-20cb-fad8-c292" name="Blast" hidden="false" targetId="6c1f-1cf7-ff25-c99e" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dfd7-add7-ed5a-f2f" name="Turbo-Laser Destructor" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="2ac2-e8ff-d331-eb78" name="Turbo-Laser Destructor" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+                  <characteristics>
+                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">96&quot;</characteristic>
+                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D3+1</characteristic>
+                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                    <characteristic name="S" typeId="2229-f494-25db-c5d3">20</characteristic>
+                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+6</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="e672-9b28-7031-6a72" name="Blast" hidden="false" targetId="6c1f-1cf7-ff25-c99e" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="255"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="805.0"/>
       </costs>
-      <categoryLinks>
-        <categoryLink targetId="75e8-57c4-40e3-1817" id="70cf-964f-78b5-4517" primary="false" name="Transport"/>
-        <categoryLink targetId="dbd4-63-af05-998" id="a5e7-ac61-d10-400d" primary="true" name="Vehicle"/>
-        <categoryLink targetId="6df-937-16bc-8c1a" id="4ed9-1d53-9e9e-572" primary="false" name="Smoke"/>
-        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="316a-7457-4035-dc13" primary="false" name="Imperium"/>
-        <categoryLink targetId="3741-4bcf-f67e-1942" id="c448-ca78-6b11-c252" primary="false" name="Land Raider Banisher"/>
-        <categoryLink targetId="d564-3284-bf44-b873" id="ed0d-2209-7ce-aeca" primary="false" name="Faction: Grey Knights"/>
-      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry id="69d-a656-fde3-6c3e" name="Land Raider Banisher" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile name="Land Raider Banisher" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="19a8-1a57-5977-53ac">
+        <profile id="19a8-1a57-5977-53ac" name="Land Raider Banisher" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
             <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">10&quot;</characteristic>
             <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">12</characteristic>
@@ -5620,22 +6255,22 @@
             <characteristic name="OC" typeId="bef7-942a-1a23-59f8">5</characteristic>
           </characteristics>
         </profile>
-        <profile name="Damaged: 1-5 Wounds Remaining" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="a6c4-1b00-1dba-8808">
+        <profile id="a6c4-1b00-1dba-8808" name="Damaged: 1-5 Wounds Remaining" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this model has 1-5 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Assault Ramp" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="4749-41d6-2cbd-4b70">
+        <profile id="4749-41d6-2cbd-4b70" name="Assault Ramp" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a unit disembarks from this model after it has made a Normal move, that unit is still eligible to declare a charge this turn.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Land Raider Banisher" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="11a-f6f2-ef6e-1aed">
+        <profile id="11a-f6f2-ef6e-1aed" name="Land Raider Banisher" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model has a transport capacity of 12 Grey Knights Infantry models. Each Terminator model takes up the space of 2 models.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Armored Tracks" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="c8f9-e2c0-904b-d29c">
+        <profile id="c8f9-e2c0-904b-d29c" name="Armored Tracks" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
           <characteristics>
             <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
             <characteristic name="A" typeId="2337-daa1-6682-b110">6</characteristic>
@@ -5648,20 +6283,28 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Deadly Demise" hidden="false" type="rule" id="ay84-xp9u-3c5j-z6he" targetId="b68a-5ded-65ac-98c">
+        <infoLink id="ay84-xp9u-3c5j-z6he" name="Deadly Demise" hidden="false" targetId="b68a-5ded-65ac-98c" type="rule">
           <modifiers>
-            <modifier type="append" value="D6" field="name"/>
+            <modifier type="append" field="name" value="D6"/>
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="70cf-964f-78b5-4517" name="Transport" hidden="false" targetId="75e8-57c4-40e3-1817" primary="false"/>
+        <categoryLink id="a5e7-ac61-d10-400d" name="Vehicle" hidden="false" targetId="dbd4-63-af05-998" primary="true"/>
+        <categoryLink id="4ed9-1d53-9e9e-572" name="Smoke" hidden="false" targetId="6df-937-16bc-8c1a" primary="false"/>
+        <categoryLink id="316a-7457-4035-dc13" name="Imperium" hidden="false" targetId="aff3-d6a3-2a95-9dc" primary="false"/>
+        <categoryLink id="c448-ca78-6b11-c252" name="Land Raider Banisher" hidden="false" targetId="3741-4bcf-f67e-1942" primary="false"/>
+        <categoryLink id="ed0d-2209-7ce-aeca" name="Faction: Grey Knights" hidden="false" targetId="d564-3284-bf44-b873" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Heavy Incinerator" hidden="false" id="d4b7-cb82-6458-a406">
+        <selectionEntry id="d4b7-cb82-6458-a406" name="Heavy Incinerator" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="a982-ab95-883c-2a2c"/>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="895f-535d-22bb-fbf2"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a982-ab95-883c-2a2c" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="895f-535d-22bb-fbf2" type="max"/>
           </constraints>
           <profiles>
-            <profile name="Heavy Incinerator" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="dff3-c0d8-cc66-886d">
+            <profile id="dff3-c0d8-cc66-886d" name="Heavy Incinerator" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">2D6</characteristic>
@@ -5674,26 +6317,20 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Ignores Cover" hidden="false" type="rule" id="810d-238c-e410-2578" targetId="4640-43e7-30b-215a"/>
-            <infoLink name="Torrent" hidden="false" type="rule" id="bbbc-1451-86cc-e097" targetId="5edf-d619-23e0-9b56"/>
+            <infoLink id="810d-238c-e410-2578" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+            <infoLink id="bbbc-1451-86cc-e097" name="Torrent" hidden="false" targetId="5edf-d619-23e0-9b56" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Twin Psycannon" hidden="false" id="88e0-4fa-8acc-7b7c">
+        <selectionEntry id="88e0-4fa-8acc-7b7c" name="Twin Psycannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2506-272c-4714-918"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e10d-d4-9a9a-8e0a"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2506-272c-4714-918" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e10d-d4-9a9a-8e0a" type="max"/>
           </constraints>
-          <infoLinks>
-            <infoLink name="Twin-linked" hidden="false" type="rule" id="df36-2c25-8bad-3dcd" targetId="cf93-ad4d-2f08-a79d"/>
-            <infoLink name="Sustained Hits" hidden="false" type="rule" id="e17b-1246-e472-ab2a" targetId="1897-c22c-9597-12b1">
-              <modifiers>
-                <modifier type="append" value="1" field="name"/>
-              </modifiers>
-            </infoLink>
-            <infoLink name="Psychic" hidden="false" type="rule" id="e178-bc33-76ae-c3cd" targetId="e9c4-2bb8-12ee-cd1b"/>
-          </infoLinks>
           <profiles>
-            <profile name="Twin Psycannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="bd0d-bf5-b1f7-108e">
+            <profile id="bd0d-bf5-b1f7-108e" name="Twin Psycannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
@@ -5705,13 +6342,25 @@
               </characteristics>
             </profile>
           </profiles>
+          <infoLinks>
+            <infoLink id="df36-2c25-8bad-3dcd" name="Twin-linked" hidden="false" targetId="cf93-ad4d-2f08-a79d" type="rule"/>
+            <infoLink id="e17b-1246-e472-ab2a" name="Sustained Hits" hidden="false" targetId="1897-c22c-9597-12b1" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value="1"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="e178-bc33-76ae-c3cd" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Hunter-killer Missile" hidden="false" id="2150-6135-3ee3-8eda">
+        <selectionEntry id="2150-6135-3ee3-8eda" name="Hunter-killer Missile" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c73-11ff-a910-dd79"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c73-11ff-a910-dd79" type="max"/>
           </constraints>
           <profiles>
-            <profile name="Hunter-killer Missile" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="3d1b-24ff-8faa-e115">
+            <profile id="3d1b-24ff-8faa-e115" name="Hunter-killer Missile" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
@@ -5724,22 +6373,18 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="One Shot" hidden="false" type="rule" id="6caf-7fbb-7235-e51b" targetId="cd26-1611-860a-91e4"/>
+            <infoLink id="6caf-7fbb-7235-e51b" name="One Shot" hidden="false" targetId="cd26-1611-860a-91e4" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Storm Bolter" hidden="false" id="9e63-91f2-e625-cce7">
+        <selectionEntry id="9e63-91f2-e625-cce7" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="65e4-f762-587-1263"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65e4-f762-587-1263" type="max"/>
           </constraints>
-          <infoLinks>
-            <infoLink name="Rapid Fire" hidden="false" type="rule" id="5da9-5d22-1197-b609" targetId="c5c8-8b58-b8b6-7786">
-              <modifiers>
-                <modifier type="append" value="2" field="name"/>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
           <profiles>
-            <profile name="Storm Bolter" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="f854-e7ec-cf28-2531">
+            <profile id="f854-e7ec-cf28-2531" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -5751,13 +6396,23 @@
               </characteristics>
             </profile>
           </profiles>
+          <infoLinks>
+            <infoLink id="5da9-5d22-1197-b609" name="Rapid Fire" hidden="false" targetId="c5c8-8b58-b8b6-7786" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value="2"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Multi-Melta" hidden="false" id="f3dd-c9b2-d7a-c917">
+        <selectionEntry id="f3dd-c9b2-d7a-c917" name="Multi-Melta" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f497-ef5f-757-8812"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f497-ef5f-757-8812" type="max"/>
           </constraints>
           <profiles>
-            <profile name="Multi-Melta" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="4481-1292-2a1f-1842">
+            <profile id="4481-1292-2a1f-1842" name="Multi-Melta" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
               <characteristics>
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
@@ -5770,16 +6425,29 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink name="Melta" hidden="false" type="rule" id="3178-5121-d2a0-5e88" targetId="7cdb-fb99-44a9-8849">
+            <infoLink id="3178-5121-d2a0-5e88" name="Melta" hidden="false" targetId="7cdb-fb99-44a9-8849" type="rule">
               <modifiers>
-                <modifier type="append" value="2" field="name"/>
+                <modifier type="append" field="name" value="2"/>
               </modifiers>
             </infoLink>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="255.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="28d0-5a52-501a-441d" name="Grey Knights Dreadnought [Legends]" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9ed-cbf4-bfe5-90bf" type="lessThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="f902-a865-891f-d0e6" name="Grey Knights Dreadnought [Legends]" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
@@ -5816,8 +6484,8 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="e10a-c76f-4f9c-a9a7" name="Left Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="aa02-2e73-1439-6345">
           <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41f8-4a04-7532-1699" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8b4-e0e8-e65b-3738" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41f8-4a04-7532-1699" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8b4-e0e8-e65b-3738" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="2c39-9ddf-60f3-bb15" name="Dreadnought combat weapon and heavy flamer" hidden="false" collective="false" import="true" type="upgrade">
@@ -5846,7 +6514,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa02-2e73-1439-6345" name="Dreadnought combat weapon and storm bolter" hidden="false" collective="false" import="true" type="upgrade">
@@ -5875,7 +6543,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="948f-cee9-86ad-47f0" name="Missile launcher and armoured feet" hidden="false" collective="false" import="true" type="upgrade">
@@ -5915,7 +6583,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="19ce-493d-f42e-f034" name="Nemesis doomglaive and incinerator" hidden="false" collective="false" import="true" type="upgrade">
@@ -5944,7 +6612,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3145-7464-4b5-1a18" name="Nemesis doomglaive and storm bolter" hidden="false" collective="false" import="true" type="upgrade">
@@ -5973,15 +6641,15 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="b641-c591-955e-302c" name="Right Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="52a2-574b-f679-fba4">
           <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="167-9181-f765-30b8" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6056-bbc8-ff6b-143e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="167-9181-f765-30b8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6056-bbc8-ff6b-143e" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="52a2-574b-f679-fba4" name="Assault cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -5999,7 +6667,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4307-f0eb-4e2b-a53a" name="Heavy plasma cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -6028,7 +6696,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e68-33b-95cd-304d" name="Multi-melta" hidden="false" collective="false" import="true" type="upgrade">
@@ -6046,7 +6714,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d4df-bdd-649c-9bd5" name="Twin lascannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -6064,7 +6732,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b687-7f63-dd41-b373" name="Heavy psycannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -6082,24 +6750,24 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="160"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="160.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="54f0-4b3f-3abe-081b" name="Grey Knights Relic Razorback [Legends]" hidden="false" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="set" value="true" field="hidden">
+        <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition type="lessThan" value="1" field="selections" scope="roster" childId="9ed-cbf4-bfe5-90bf" shared="true" includeChildForces="true" includeChildSelections="true"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9ed-cbf4-bfe5-90bf" type="lessThan"/>
           </conditions>
         </modifier>
       </modifiers>
-    </selectionEntry>
-    <selectionEntry id="54f0-4b3f-3abe-081b" name="Grey Knights Relic Razorback [Legends]" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="d956-2abf-ad72-bb60" name="Grey Knights Relic Razorback [Legends]" hidden="false" typeId="c547-1836-d8a-ff4f" typeName="Unit">
           <characteristics>
@@ -6152,7 +6820,7 @@
       <selectionEntries>
         <selectionEntry id="23e0-78c1-6f77-e985" name="Hunter-killer Missile" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b47-b017-2100-a87a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b47-b017-2100-a87a" type="max"/>
           </constraints>
           <profiles>
             <profile id="effe-7430-7b68-efc5" name="Hunter-killer Missile" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
@@ -6168,12 +6836,12 @@
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7ee9-e9ac-b677-24a9" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e8a-de74-5532-b22b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e8a-de74-5532-b22b" type="max"/>
           </constraints>
           <profiles>
             <profile id="ccf1-3ed6-699e-49b4" name="Storm Bolter" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
@@ -6196,15 +6864,15 @@
             </infoLink>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="99e9-386-f00-afe1" name="Weapon Option" hidden="false" collective="false" import="true" defaultSelectionEntryId="850e-b813-8e4a-1314">
           <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5568-9273-6986-65ab" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2378-2949-ebea-519c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5568-9273-6986-65ab" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2378-2949-ebea-519c" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="d639-d780-425c-67d9" name="Twin Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
@@ -6222,7 +6890,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="850e-b813-8e4a-1314" name="Twin Assault Cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -6240,7 +6908,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f9d6-568b-0b7a-7770" name="Twin lascannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -6258,7 +6926,7 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9cd8-d57e-2c72-1b6e" name="Heavy psycannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -6276,56 +6944,55 @@
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="95"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="95.0"/>
       </costs>
-      <modifiers>
-        <modifier type="set" value="true" field="hidden">
-          <conditions>
-            <condition type="lessThan" value="1" field="selections" scope="roster" childId="9ed-cbf4-bfe5-90bf" shared="true" includeChildForces="true" includeChildSelections="true"/>
-          </conditions>
-        </modifier>
-      </modifiers>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Detachment" hidden="false" id="c05f-e67a-d2db-b3de">
+    <selectionEntry id="c05f-e67a-d2db-b3de" name="Detachment" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1c7-34b8-6dc3-8c60" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e456-f904-cb4b-d10e" type="min"/>
+      </constraints>
       <categoryLinks>
-        <categoryLink targetId="4ac9-fd30-1e3d-b249" id="9aae-3f8d-a1c6-2d54" primary="true" name="Configuration"/>
+        <categoryLink id="9aae-3f8d-a1c6-2d54" name="Configuration" hidden="false" targetId="4ac9-fd30-1e3d-b249" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Detachments" hidden="false" type="selectionEntryGroup" id="dca8-c3a1-c974-8f55" targetId="f7f3-a061-3f69-1432">
+        <entryLink id="dca8-c3a1-c974-8f55" name="Detachments" hidden="false" collective="false" import="true" targetId="f7f3-a061-3f69-1432" type="selectionEntryGroup">
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d63a-c228-6ada-324b"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="adf5-ce4d-6684-99dc"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d63a-c228-6ada-324b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adf5-ce4d-6684-99dc" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
-      <constraints>
-        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f1c7-34b8-6dc3-8c60"/>
-        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e456-f904-cb4b-d10e"/>
-      </constraints>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Warlord" hidden="false" id="beae-4593-3686-1672">
+    <selectionEntry id="beae-4593-3686-1672" name="Warlord" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f97-b336-21f1-ce3d" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="788e-3612-f2c0-5c3f" type="max"/>
+      </constraints>
       <categoryLinks>
-        <categoryLink targetId="5c0e-4c31-d51b-e470" id="30ba-385e-aece-34ef" primary="false" name="Warlord"/>
+        <categoryLink id="30ba-385e-aece-34ef" name="Warlord" hidden="false" targetId="5c0e-4c31-d51b-e470" primary="false"/>
       </categoryLinks>
-      <constraints>
-        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f97-b336-21f1-ce3d"/>
-        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="788e-3612-f2c0-5c3f"/>
-      </constraints>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="d0e-7460-ee7b-660f" collective="true">
+    <selectionEntry id="d0e-7460-ee7b-660f" name="Close combat weapon" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4d04-59c0-106e-da72"/>
-        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ecd3-6295-3b83-5c1f"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d04-59c0-106e-da72" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecd3-6295-3b83-5c1f" type="max"/>
       </constraints>
       <profiles>
-        <profile name="Close combat weapon" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="d90e-6422-f76d-8bae">
+        <profile id="d90e-6422-f76d-8bae" name="Close combat weapon" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
           <characteristics>
             <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
             <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
@@ -6337,14 +7004,17 @@
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Servitor&apos;s tools" hidden="false" id="bc82-5462-1e1-5008" collective="true">
+    <selectionEntry id="bc82-5462-1e1-5008" name="Servitor&apos;s tools" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2436-3f50-4280-2c94-min"/>
-        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2436-3f50-4280-2c94-max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2436-3f50-4280-2c94-min" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2436-3f50-4280-2c94-max" type="max"/>
       </constraints>
       <profiles>
-        <profile name="Servitor&apos;s tools" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="65cb-c328-3324-9c94">
+        <profile id="65cb-c328-3324-9c94" name="Servitor&apos;s tools" hidden="false" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons">
           <characteristics>
             <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
             <characteristic name="A" typeId="2337-daa1-6682-b110">1</characteristic>
@@ -6356,10 +7026,13 @@
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Incinerator" hidden="false" id="17ed-2f7b-bf3a-3c94">
+    <selectionEntry id="17ed-2f7b-bf3a-3c94" name="Incinerator" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile name="Incinerator" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="2128-f1c4-afbc-82af">
+        <profile id="2128-f1c4-afbc-82af" name="Incinerator" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
           <characteristics>
             <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
             <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
@@ -6372,13 +7045,16 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Ignores Cover" hidden="false" type="rule" id="9de1-9cf8-d94e-d38c" targetId="4640-43e7-30b-215a"/>
-        <infoLink name="Torrent" hidden="false" type="rule" id="628c-89f4-f3c8-74e2" targetId="5edf-d619-23e0-9b56"/>
+        <infoLink id="9de1-9cf8-d94e-d38c" name="Ignores Cover" hidden="false" targetId="4640-43e7-30b-215a" type="rule"/>
+        <infoLink id="628c-89f4-f3c8-74e2" name="Torrent" hidden="false" targetId="5edf-d619-23e0-9b56" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Psilencer" hidden="false" id="d526-d040-807c-34f6">
+    <selectionEntry id="d526-d040-807c-34f6" name="Psilencer" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile name="Psilencer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="4063-edc3-baa4-6475">
+        <profile id="4063-edc3-baa4-6475" name="Psilencer" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
           <characteristics>
             <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
             <characteristic name="A" typeId="3bb-c35f-f54-fb08">6</characteristic>
@@ -6391,20 +7067,20 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink name="Sustained Hits" hidden="false" type="rule" id="b6de-2b73-7a93-b18d" targetId="1897-c22c-9597-12b1">
+        <infoLink id="b6de-2b73-7a93-b18d" name="Sustained Hits" hidden="false" targetId="1897-c22c-9597-12b1" type="rule">
           <modifiers>
-            <modifier type="append" value="1" field="name"/>
+            <modifier type="append" field="name" value="1"/>
           </modifiers>
         </infoLink>
-        <infoLink name="Psychic" hidden="false" type="rule" id="74a0-8aa1-1b80-cc8b" targetId="e9c4-2bb8-12ee-cd1b"/>
+        <infoLink id="74a0-8aa1-1b80-cc8b" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Psycannon" hidden="false" id="e520-9c7-d10c-897d">
-      <infoLinks>
-        <infoLink name="Psychic" hidden="false" type="rule" id="2783-fc97-e3e4-f76f" targetId="e9c4-2bb8-12ee-cd1b"/>
-      </infoLinks>
+    <selectionEntry id="e520-9c7-d10c-897d" name="Psycannon" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile name="Psycannon" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="3701-b2f4-a180-cd80">
+        <profile id="3701-b2f4-a180-cd80" name="Psycannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
           <characteristics>
             <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
             <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
@@ -6416,208 +7092,146 @@
           </characteristics>
         </profile>
       </profiles>
+      <infoLinks>
+        <infoLink id="2783-fc97-e3e4-f76f" name="Psychic" hidden="false" targetId="e9c4-2bb8-12ee-cd1b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
-    <selectionEntryGroup name="Enhancements" hidden="false" id="c440-b056-f09a-c88a">
+    <selectionEntryGroup id="c440-b056-f09a-c88a" name="Enhancements - Teleport Strike Force" hidden="false" collective="false" import="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d83-78f6-ed20-4114" type="max"/>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1d7d-b153-bb06-1a4f" type="max"/>
+      </constraints>
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Domina Liber Daemonica" hidden="false" id="5311-c819-50b2-1464">
-          <profiles>
-            <profile name="Domina Liber Daemonica" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" id="a4g6-h8l0-1x7l-0jt5">
-              <characteristics>
-                <characteristic name="Description" typeId="3c5h-9n5f-x6h9-wfry">Grey Knights model only. Each time the bearer makes a melee attack add 1 to the Wound roll and, if that attack targets a Daemon unit, add 1 to the Damage characteristic of that attack as well.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
+        <selectionEntry id="5311-c819-50b2-1464" name="Domina Liber Daemonica" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" value="true" field="hidden">
+            <modifier type="set" field="hidden" value="true">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="roster" childId="5311-c819-50b2-1464" shared="true" includeChildForces="true" includeChildSelections="true"/>
-                    <condition type="lessThan" value="1" field="selections" scope="parent" childId="5311-c819-50b2-1464" shared="true" includeChildForces="true" includeChildSelections="true"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5311-c819-50b2-1464" type="atLeast"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5311-c819-50b2-1464" type="lessThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
+          <profiles>
+            <profile id="a4g6-h8l0-1x7l-0jt5" name="Domina Liber Daemonica" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+              <characteristics>
+                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Grey Knights model only. Each time the bearer makes a melee attack add 1 to the Wound roll and, if that attack targets a Daemon unit, add 1 to the Damage characteristic of that attack as well.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
-            <cost name="pts" typeId="51b2-306e-1021-d207" value="20"/>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="20.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="First to the Fray" hidden="false" id="f290-4bcc-1798-6868">
-          <profiles>
-            <profile name="First to the Fray" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" id="p1x9-r402-ww99-xorm">
-              <characteristics>
-                <characteristic name="Description" typeId="mpz5-ac04-dc93-ppc1">Grey Knights model with the Deep Strike ability only. The bearer’s unit must start the battle in Reserves, but neither it, nor any Transport it is embarked within, is counted towards any limits the mission places on the number of Strategic Reserves units you can have. That unit can be set up using its Deep Strike ability in the Reinforcements step of your first, second or third Movement phase, regardless of any mission rules.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
+        <selectionEntry id="f290-4bcc-1798-6868" name="First to the Fray" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" value="true" field="hidden">
+            <modifier type="set" field="hidden" value="true">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="roster" childId="f290-4bcc-1798-6868" shared="true" includeChildForces="true" includeChildSelections="true"/>
-                    <condition type="lessThan" value="1" field="selections" scope="parent" childId="f290-4bcc-1798-6868" shared="true" includeChildForces="true" includeChildSelections="true"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f290-4bcc-1798-6868" type="atLeast"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f290-4bcc-1798-6868" type="lessThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
+          <profiles>
+            <profile id="p1x9-r402-ww99-xorm" name="First to the Fray" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+              <characteristics>
+                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Grey Knights model with the Deep Strike ability only. The bearer’s unit must start the battle in Reserves, but neither it, nor any Transport it is embarked within, is counted towards any limits the mission places on the number of Strategic Reserves units you can have. That unit can be set up using its Deep Strike ability in the Reinforcements step of your first, second or third Movement phase, regardless of any mission rules.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
-            <cost name="pts" typeId="51b2-306e-1021-d207" value="35"/>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="35.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Inescapable Wrath" hidden="false" id="8084-85d-a3a4-87e6">
-          <profiles>
-            <profile name="Inescapable Wrath" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" id="4o2d-b9qr-3b0z-8855">
-              <characteristics>
-                <characteristic name="Description" typeId="7j40-a0c4-gguu-3390">Grey Knights model only. Add 1 to Charge rolls made for the bearer’s unit.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
+        <selectionEntry id="8084-85d-a3a4-87e6" name="Inescapable Wrath" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" value="true" field="hidden">
+            <modifier type="set" field="hidden" value="true">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="roster" childId="8084-85d-a3a4-87e6" shared="true" includeChildForces="true" includeChildSelections="true"/>
-                    <condition type="lessThan" value="1" field="selections" scope="parent" childId="8084-85d-a3a4-87e6" shared="true" includeChildForces="true" includeChildSelections="true"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8084-85d-a3a4-87e6" type="atLeast"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8084-85d-a3a4-87e6" type="lessThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
+          <profiles>
+            <profile id="4o2d-b9qr-3b0z-8855" name="Inescapable Wrath" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+              <characteristics>
+                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Grey Knights model only. Add 1 to Charge rolls made for the bearer’s unit.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
-            <cost name="pts" typeId="51b2-306e-1021-d207" value="15"/>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="15.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Sigil of Exigence" hidden="false" id="d0c9-fd98-de1b-6d43">
-          <profiles>
-            <profile name="Sigil of Exigence" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" id="b262-6252-ce59-4b30">
-              <characteristics>
-                <characteristic name="Description" typeId="p1x4-jt0e-8t67-v40d">Grey Knights model only. Once per battle, in your opponent’s Shooting phase, when the bearer’s unit is selected as the target of a ranged attack, you can remove the bearer’s unit from the battlefield and then set it back up again anywhere on the battlefield that is more than 9&quot; horizontally away from all enemy models. If the bearer is no longer an eligible target, your opponent can then select new targets for any attacks that had targeted the bearer’s unit.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
+        <selectionEntry id="d0c9-fd98-de1b-6d43" name="Sigil of Exigence" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" value="true" field="hidden">
+            <modifier type="set" field="hidden" value="true">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="roster" childId="d0c9-fd98-de1b-6d43" shared="true" includeChildForces="true" includeChildSelections="true"/>
-                    <condition type="lessThan" value="1" field="selections" scope="parent" childId="d0c9-fd98-de1b-6d43" shared="true" includeChildForces="true" includeChildSelections="true"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d0c9-fd98-de1b-6d43" type="atLeast"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d0c9-fd98-de1b-6d43" type="lessThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
+          <profiles>
+            <profile id="b262-6252-ce59-4b30" name="Sigil of Exigence" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+              <characteristics>
+                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Grey Knights model only. Once per battle, in your opponent’s Shooting phase, when the bearer’s unit is selected as the target of a ranged attack, you can remove the bearer’s unit from the battlefield and then set it back up again anywhere on the battlefield that is more than 9&quot; horizontally away from all enemy models. If the bearer is no longer an eligible target, your opponent can then select new targets for any attacks that had targeted the bearer’s unit.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
-            <cost name="pts" typeId="51b2-306e-1021-d207" value="30"/>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="30.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <constraints>
-        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5d83-78f6-ed20-4114" includeChildSelections="false" includeChildForces="false"/>
-        <constraint type="max" value="3" field="selections" scope="roster" shared="true" id="1d7d-b153-bb06-1a4f" includeChildForces="true" includeChildSelections="true"/>
-      </constraints>
-      <comment>Teleport Strike Force</comment>
     </selectionEntryGroup>
-    <selectionEntryGroup name="Detachments" hidden="false" id="f7f3-a061-3f69-1432" defaultSelectionEntryId="bcb7-c2a7-e7fb-3aae">
+    <selectionEntryGroup id="f7f3-a061-3f69-1432" name="Detachments" hidden="false" collective="false" import="false" defaultSelectionEntryId="bcb7-c2a7-e7fb-3aae">
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Teleport Strike Force" hidden="false" id="bcb7-c2a7-e7fb-3aae"/>
+        <selectionEntry id="bcb7-c2a7-e7fb-3aae" name="Teleport Strike Force" hidden="false" collective="false" import="true" type="upgrade">
+          <costs>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="0.0"/>
+          </costs>
+        </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
-  <entryLinks>
-    <entryLink import="true" name="Brother-Captain" hidden="false" type="selectionEntry" id="8421-ca98-c324-ec3a" targetId="dce9-6eb4-fa33-e869"/>
-    <entryLink import="true" name="Brother-Captain Stern" hidden="false" type="selectionEntry" id="1712-989f-bbec-8109" targetId="aec2-ded6-fa0-3b75"/>
-    <entryLink import="true" name="Brotherhood Champion" hidden="false" type="selectionEntry" id="b391-1ca8-ca39-ece7" targetId="2c81-4e74-8707-3117"/>
-    <entryLink import="true" name="Brotherhood Chaplain" hidden="false" type="selectionEntry" id="47d8-1a0a-e584-991" targetId="b9b1-d698-1e98-da45"/>
-    <entryLink import="true" name="Brotherhood Librarian" hidden="false" type="selectionEntry" id="eb42-25e1-cb7-81e0" targetId="5412-1f01-b7cc-bf12"/>
-    <entryLink import="true" name="Brotherhood Techmarine" hidden="false" type="selectionEntry" id="19bb-564d-866d-ff13" targetId="f667-5267-f241-37"/>
-    <entryLink import="true" name="Brotherhood Terminator Squad" hidden="false" type="selectionEntry" id="1462-a777-45ab-a8b5" targetId="a037-a89c-f59f-8b1e"/>
-    <entryLink import="true" name="Castellan Crowe" hidden="false" type="selectionEntry" id="5c7b-487d-a534-77bd" targetId="9ddb-760d-8cf7-1c8a"/>
-    <entryLink import="true" name="Grand Master" hidden="false" type="selectionEntry" id="a304-8dfa-851c-b53d" targetId="1a56-706b-a8f1-631a"/>
-    <entryLink import="true" name="Grand Master in Nemesis Dreadknight" hidden="false" type="selectionEntry" id="3066-9274-c887-86b" targetId="3625-f9f1-122b-bf9d"/>
-    <entryLink import="true" name="Grand Master Voldus" hidden="false" type="selectionEntry" id="e3ba-ed19-bc91-81ee" targetId="7256-bb3a-3e79-31fe"/>
-    <entryLink import="true" name="Grey Knights Land Raider" hidden="false" type="selectionEntry" id="99b4-6a62-b540-e864" targetId="512d-b972-911e-4cac"/>
-    <entryLink import="true" name="Grey Knights Land Raider Crusader" hidden="false" type="selectionEntry" id="ed2d-a39d-c9e1-7e2e" targetId="4c63-cca-8d26-6330"/>
-    <entryLink import="true" name="Grey Knights Land Raider Redeemer" hidden="false" type="selectionEntry" id="8d8f-b8f9-8344-ef40" targetId="ada7-eb0b-c920-d77f"/>
-    <entryLink import="true" name="Grey Knights Razorback" hidden="false" type="selectionEntry" id="9d6b-4332-27c3-c669" targetId="841f-98b-fbf3-c8ee"/>
-    <entryLink import="true" name="Grey Knights Rhino" hidden="false" type="selectionEntry" id="41e6-9a15-f40e-149f" targetId="5ffd-f698-a1bb-fba7"/>
-    <entryLink import="true" name="Grey Knights Stormhawk Interceptor" hidden="false" type="selectionEntry" id="6906-148b-2d4a-f6cd" targetId="fa-e288-2107-d22e"/>
-    <entryLink import="true" name="Grey Knights Stormraven Gunship" hidden="false" type="selectionEntry" id="9ad4-5c9e-4d7d-8ffd" targetId="2efe-459b-9562-e7a9"/>
-    <entryLink import="true" name="Grey Knights Stormtalon Gunship" hidden="false" type="selectionEntry" id="98a2-a561-b183-56a" targetId="84ac-b9ea-921f-9082"/>
-    <entryLink import="true" name="Grey Knights Venerable Dreadnought" hidden="false" type="selectionEntry" id="b24d-be83-c5fe-d3fc" targetId="bd43-b303-66e0-4c10"/>
-    <entryLink import="true" name="Interceptor Squad" hidden="false" type="selectionEntry" id="a53-5d6c-8148-4393" targetId="d9f7-71b7-8e67-7f44"/>
-    <entryLink import="true" name="Kaldor Draigo" hidden="false" type="selectionEntry" id="c945-9a85-5ea3-2142" targetId="7a19-5235-692b-320d"/>
-    <entryLink import="true" name="Land Raider Banisher" hidden="false" type="selectionEntry" id="db7e-ce0-7ace-dc10" targetId="69d-a656-fde3-6c3e"/>
-    <entryLink import="true" name="Nemesis Dreadknight" hidden="false" type="selectionEntry" id="9342-1cf-b2ab-b143" targetId="5458-a458-c51d-c4e9"/>
-    <entryLink import="true" name="Paladin Squad" hidden="false" type="selectionEntry" id="1e9b-5681-eaf7-5e08" targetId="6528-4634-c2cf-2840"/>
-    <entryLink import="true" name="Grey Knights Thunderhawk Gunship" hidden="false" type="selectionEntry" id="b257-3749-9bb2-4d4d" targetId="8989-2fd2-4d29-e795"/>
-    <entryLink import="true" name="Purgation Squad" hidden="false" type="selectionEntry" id="8440-8405-d8ce-1592" targetId="e8ad-bd40-5952-6859"/>
-    <entryLink import="true" name="Purifier Squad" hidden="false" type="selectionEntry" id="9893-e746-2796-740" targetId="8865-df22-1629-bf02"/>
-    <entryLink import="true" name="Servitors" hidden="false" type="selectionEntry" id="52b1-79b1-5bc6-575e" targetId="35ed-7890-6c56-18b7"/>
-    <entryLink import="true" name="Strike Squad" hidden="false" type="selectionEntry" id="45ef-125c-ae4f-394d" targetId="d81f-c9ac-e338-ba37"/>
-    <entryLink import="true" name="Detachment" hidden="false" type="selectionEntry" id="b859-7064-3a1e-1577" targetId="c05f-e67a-d2db-b3de"/>
-    <entryLink import="true" name="Grey Knights Relic Razorback [Legends]" hidden="false" type="selectionEntry" id="b234-2a9e-174d-90b3" targetId="54f0-4b3f-3abe-081b"/>
-    <entryLink import="true" name="Grey Knights Dreadnought [Legends]" hidden="false" type="selectionEntry" id="4bb5-c50e-a835-38d1" targetId="28d0-5a52-501a-441d"/>
-    <entryLink import="true" name="Show/Hide Options" hidden="false" type="selectionEntry" id="e4b-7fa2-e394-baff" targetId="e8ef-836a-a9d1-901d">
-      <entryLinks>
-        <entryLink import="true" name="Show Agents of the Imperium" hidden="false" type="selectionEntry" id="537-702c-e58c-86a3" targetId="e08b-2448-5606-fefb"/>
-        <entryLink import="true" name="Show Imperial Knights" hidden="false" type="selectionEntry" id="e981-3288-d103-387d" targetId="e82c-6f8c-2b97-a287"/>
-        <entryLink import="true" name="Show Titans" hidden="false" type="selectionEntry" id="e48a-8350-26a3-9971" targetId="f26b-79db-80e0-3a3b"/>
-      </entryLinks>
-    </entryLink>
-  </entryLinks>
-  <categoryEntries>
-    <categoryEntry name="Brother-Captain" hidden="false" id="71ac-a100-1ec8-14e9"/>
-    <categoryEntry name="Brother-Captain Stern" hidden="false" id="9e54-c14b-9ec9-e387"/>
-    <categoryEntry name="Brotherhood Champion" hidden="false" id="c427-b327-40a0-a401"/>
-    <categoryEntry name="Brotherhood Chaplain" hidden="false" id="ebf4-5ffe-19e7-c6c7"/>
-    <categoryEntry name="Brotherhood Librarian" hidden="false" id="bd80-12a6-cd23-96c9"/>
-    <categoryEntry name="Brotherhood Techmarine" hidden="false" id="c352-657f-d2cc-adcf"/>
-    <categoryEntry name="Brotherhood Terminator Squad" hidden="false" id="cddf-ac1-4a0d-8e48"/>
-    <categoryEntry name="Castellan Crowe" hidden="false" id="de95-1b68-44cf-7ca9"/>
-    <categoryEntry name="Grand Master" hidden="false" id="ce31-227c-65ca-e27e"/>
-    <categoryEntry name="Grand Master in Nemesis Dreadknight" hidden="false" id="a738-1a96-db57-ba6f"/>
-    <categoryEntry name="Grand Master Voldus" hidden="false" id="472c-f807-880-b6"/>
-    <categoryEntry name="Grey Knights Land Raider" hidden="false" id="adfb-534b-3eb7-2781"/>
-    <categoryEntry name="Grey Knights Land Raider Crusader" hidden="false" id="4a04-1f1b-8ffb-b183"/>
-    <categoryEntry name="Grey Knights Land Raider Redeemer" hidden="false" id="51dd-461e-1657-1017"/>
-    <categoryEntry name="Grey Knights Razorback" hidden="false" id="88ad-5f29-ba09-9427"/>
-    <categoryEntry name="Grey Knights Rhino" hidden="false" id="5ced-f445-91c2-a55e"/>
-    <categoryEntry name="Grey Knights Stormhawk Interceptor" hidden="false" id="82f-4771-c58e-1755"/>
-    <categoryEntry name="Grey Knights Stormraven Gunship" hidden="false" id="54b8-5bba-f749-e5ef"/>
-    <categoryEntry name="Grey Knights Stormtalon Gunship" hidden="false" id="99eb-b003-79ba-7d46"/>
-    <categoryEntry name="Grey Knights Thunderhawk Gunship" hidden="false" id="f580-2968-19f3-1320"/>
-    <categoryEntry name="Grey Knights Venerable Dreadnought" hidden="false" id="33d4-b50a-18e8-16e8"/>
-    <categoryEntry name="Interceptor Squad" hidden="false" id="b7d3-6b00-c657-ebd7"/>
-    <categoryEntry name="Kaldor Draigo" hidden="false" id="77b6-bfe8-648b-9fb4"/>
-    <categoryEntry name="Land Raider Banisher" hidden="false" id="3741-4bcf-f67e-1942"/>
-    <categoryEntry name="Nemesis Dreadknight" hidden="false" id="8083-7b7a-c9d7-fd31"/>
-    <categoryEntry name="Paladin Squad" hidden="false" id="9020-9fb5-8ef8-5ad4"/>
-    <categoryEntry name="Purgation Squad" hidden="false" id="8084-5bdd-7c6-bae4"/>
-    <categoryEntry name="Purifier Squad" hidden="false" id="67f8-444-b8b7-ad0"/>
-    <categoryEntry name="Servitors" hidden="false" id="5bc8-a8b7-1c69-9043"/>
-    <categoryEntry name="Strike Squad" hidden="false" id="103f-a8cd-8c1f-24df"/>
-    <categoryEntry id="4c57-a2d1-fe45-4ec1" name="Grey Knights Dreadnought [Legends]" hidden="false"/>
-    <categoryEntry id="6ee2-b8d8-f50b-67e3" name="Grey Knights Relic Razorback [Legends]" hidden="false"/>
-  </categoryEntries>
   <sharedProfiles>
-    <profile name="Invulnerable Save (4+)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="df6-e949-835b-ad0d">
+    <profile id="df6-e949-835b-ad0d" name="Invulnerable Save (4+)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+      <comment>4+ Single model</comment>
       <characteristics>
         <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model has a 4+ invulnerable save.</characteristic>
       </characteristics>
-      <comment>4+ Single model</comment>
     </profile>
-    <profile name="Invulnerable Save (4+)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="a343-738-c273-4e13">
+    <profile id="a343-738-c273-4e13" name="Invulnerable Save (4+)" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
+      <comment>4+ Unit</comment>
       <characteristics>
         <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This unit has a 4+ Invulnerable Save</characteristic>
       </characteristics>
-      <comment>4+ Unit</comment>
     </profile>
   </sharedProfiles>
+  <catalogueLinks>
+    <catalogueLink id="f3e4-7fc3-8f57-6303" name="Imperium - Imperial Knights" targetId="1b6d-dc06-5db9-c7d1" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="575c-d0f9-7fdc-2ddb" name="Imperium - Imperial Agents" targetId="b00-cd86-4b4c-97ba" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="9d21-5393-3605-a43e" name="Library - Titans" targetId="7481-280e-b55e-7867" type="catalogue" importRootEntries="false"/>
+  </catalogueLinks>
 </catalogue>


### PR DESCRIPTION
Removed the heavy weapon options from the Grey Knight Terminator Ancient, as they are only allowed to bring a Stormbolter.  The Paladin Ancient can bring any heavy weapon and remains unchanged.